### PR TITLE
Fixed TextColor Update in MaterialButtonRenderer (iOS)

### DIFF
--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -369,7 +369,7 @@ namespace XF.Material.iOS.Renderers
                     this.Control.Elevate(RESTING_ELEVATION);
                 }
 
-                if (_materialButton.ButtonType == MaterialButtonType.Elevated && _materialButton.ButtonType == MaterialButtonType.Flat)
+                if (_materialButton.ButtonType == MaterialButtonType.Elevated || _materialButton.ButtonType == MaterialButtonType.Flat)
                 {
                     _materialButton.TextColor = _normalTextColor.ToColor();
                 }


### PR DESCRIPTION
MaterialButtonRenderer was using a logical AND rather than a logical OR
to when checking ButtonType causing the TextColor update to be skipped

Fixes #45 