### PR TITLE
Fix issue with disabled MaterialButton text color not updating on iOS

### DIFF
--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -389,7 +389,7 @@ namespace XF.Material.iOS.Renderers
                     this.Control.Elevate(0);
                 }
 
-                if (_materialButton.ButtonType == MaterialButtonType.Elevated && _materialButton.ButtonType == MaterialButtonType.Flat)
+                if (_materialButton.ButtonType == MaterialButtonType.Elevated || _materialButton.ButtonType == MaterialButtonType.Flat)
                 {
                     _materialButton.TextColor = _disabledTextColor.ToColor();
                 }


### PR DESCRIPTION
Similar to the active text color, the iOS renderer was using a logical
OR rather than a logical AND when checking for ButtonType

fixes #50 