### PR TITLE
Added Ripple effect to MaterialCard for iOS and Android. 

### DIFF
--- a/MaterialMvvmSample/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
+++ b/MaterialMvvmSample/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>

--- a/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
+++ b/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <local:BaseMainView x:Class="MaterialMvvmSample.Views.MainView"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -72,6 +72,7 @@
                             <material:MaterialCard Margin="4"
                                 Padding="16,8,4,8"
                                 Elevation="2"
+                                IsClickable="true"
                                 IsClippedToBounds="False">
                                 <View.GestureRecognizers>
                                     <TapGestureRecognizer Command="{Binding Source={x:Reference Root}, Path=BindingContext.JobSelectedCommand}"

--- a/XF.Material/XF.Material.Droid/Renderers/MaterialCardRenderer.cs
+++ b/XF.Material/XF.Material.Droid/Renderers/MaterialCardRenderer.cs
@@ -1,19 +1,46 @@
-﻿using Android.Content;
+﻿using Android.App;
+using Android.Content;
 using Android.OS;
+using Android.Util;
+using Android.Views;
 using System.ComponentModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using XF.Material.Droid.Renderers;
 using XF.Material.Forms.UI;
+using static Android.Views.View;
 
 [assembly: ExportRenderer(typeof(MaterialCard), typeof(MaterialCardRenderer))]
 namespace XF.Material.Droid.Renderers
 {
-    public class MaterialCardRenderer : Xamarin.Forms.Platform.Android.AppCompat.FrameRenderer
+    public class MaterialCardRenderer : Xamarin.Forms.Platform.Android.AppCompat.FrameRenderer, IOnTouchListener
     {
         private MaterialCard _materialCard;
 
         public MaterialCardRenderer(Context context) : base(context) { }
+
+        public bool OnTouch(Android.Views.View v, MotionEvent e)
+        {
+            if (this._materialCard.GestureRecognizers.Count > 0)
+            {
+                if (this.Control.Foreground != null)
+                {
+                    if (e.Action == MotionEventActions.Down)
+                    {
+                        this.Control.Foreground.SetHotspot(e.GetX(), e.GetY());
+                        this.Control.Pressed = true;
+                    }
+                    else if (e.Action == MotionEventActions.Up ||
+                        e.Action == MotionEventActions.Cancel ||
+                        e.Action == MotionEventActions.Outside)
+                    {
+                        this.Control.Pressed = false;
+                    }
+                }
+            }
+            return false;
+        }
+
 
         protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
         {
@@ -33,6 +60,9 @@ namespace XF.Material.Droid.Renderers
                 #endregion
 
                 this.Control.Elevate(_materialCard.Elevation);
+
+                this.SetClickable();
+                this.Control.SetOnTouchListener(this);
             }
         }
 
@@ -44,6 +74,27 @@ namespace XF.Material.Droid.Renderers
             {
                 this.Control.Elevate(_materialCard.Elevation);
             }
+
+            if (e?.PropertyName == nameof(MaterialCard.IsClickable))
+            {
+                this.SetClickable();
+
+            }
+        }
+
+        protected void SetClickable()
+        {
+            bool clickable = _materialCard.IsClickable;
+            if (clickable && this.Control.Foreground == null)
+            {
+                TypedValue outValue = new TypedValue();
+                this.Context.Theme.ResolveAttribute(
+                    Resource.Attribute.selectableItemBackground, outValue, true);
+                this.Control.Foreground = this.Context.GetDrawable(outValue.ResourceId);
+            }
+
+            this.Control.Focusable = clickable;
+            this.Control.Clickable = clickable;
         }
     }
 }

--- a/XF.Material/XF.Material.Droid/XF.Material.Droid.csproj
+++ b/XF.Material/XF.Material.Droid/XF.Material.Droid.csproj
@@ -15,7 +15,6 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XF.Material/XF.Material.Forms/UI/MaterialCard.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialCard.cs
@@ -15,12 +15,26 @@ namespace XF.Material.Forms.UI
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(int), typeof(MaterialCard), 1);
 
         /// <summary>
+        /// Backing field for the bindable property <see cref="IsClickable"/>.
+        /// </summary>
+        public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(MaterialCard), false);
+
+        /// <summary>
         /// Gets or sets the virtual distance along the z-axis for emphasis.
         /// </summary>
         public int Elevation
         {
             get => (int)this.GetValue(ElevationProperty);
             set => this.SetValue(ElevationProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating of the card is clickable with a ripple effect.
+        /// </summary>
+        public bool IsClickable
+        {
+            get => (bool)this.GetValue(IsClickableProperty);
+            set => this.SetValue(IsClickableProperty, value);
         }
 
         /// <summary>

--- a/XF.Material/XF.Material.iOS/GestureRecognizers/MaterialRippleGestureRecognizer.cs
+++ b/XF.Material/XF.Material.iOS/GestureRecognizers/MaterialRippleGestureRecognizer.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using CoreAnimation;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+using XF.Material.iOS.Renderers;
+
+namespace XF.Material.iOS.GestureRecognizers
+{
+    public class MaterialRippleGestureRecognizer : UITapGestureRecognizer, IUIGestureRecognizerDelegate
+    {
+        private readonly CABasicAnimation _rippleAnimation;
+        private readonly CABasicAnimation _fadeAnimation;
+        private readonly CABasicAnimation _backgroundFadeInAnimation;
+        private readonly CABasicAnimation _backgroundFadeOutAnimation;
+        private readonly CALayer _backgroundLayer;
+        private readonly CAShapeLayer _rippleLayer;
+        private UIView _touchView;
+        private bool _isStarted;
+
+        public MaterialRippleGestureRecognizer(CGColor rippleColor, UIView view)
+        {
+            _rippleAnimation = CABasicAnimation.FromKeyPath("path");
+            _rippleAnimation.Duration = 0.3;
+            _rippleAnimation.FillMode = CAFillMode.Forwards;
+            _rippleAnimation.RemovedOnCompletion = true;
+
+            _fadeAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _fadeAnimation.Duration = 0.3;
+            _fadeAnimation.FillMode = CAFillMode.Forwards;
+            _fadeAnimation.RemovedOnCompletion = true;
+            _fadeAnimation.From = FromObject(0.66f);
+            _fadeAnimation.To = FromObject(0.0f);
+
+            _backgroundFadeInAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _backgroundFadeInAnimation.Duration = 0.3;
+            _backgroundFadeInAnimation.FillMode = CAFillMode.Forwards;
+            _backgroundFadeInAnimation.RemovedOnCompletion = false;
+            _backgroundFadeInAnimation.From = FromObject(0.0f);
+            _backgroundFadeInAnimation.To = FromObject(0.20f);
+
+            _backgroundFadeOutAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _backgroundFadeOutAnimation.Duration = 0.3;
+            _backgroundFadeOutAnimation.FillMode = CAFillMode.Forwards;
+            _backgroundFadeOutAnimation.RemovedOnCompletion = true;
+            _backgroundFadeOutAnimation.From = FromObject(0.20f);
+            _backgroundFadeOutAnimation.To = FromObject(0.0f);
+
+            _rippleLayer = new CAShapeLayer();
+            _rippleLayer.FillColor = rippleColor;
+            _rippleLayer.MasksToBounds = true;
+
+            _backgroundLayer = new CALayer();
+            _backgroundLayer.BackgroundColor = rippleColor;
+            _backgroundLayer.MasksToBounds = true;
+            _backgroundLayer.Opacity = 0;
+
+            _isStarted = false;
+            _touchView = view;
+            Delegate = this;
+        }
+
+        [Export("gestureRecognizer:shouldReceiveTouch:")]
+        public new bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+        {
+            if (touch.View is UIButton)
+                return false;
+
+            return true;
+        }
+
+
+        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        {
+            base.TouchesBegan(touches, evt);
+
+            AnimateStart(touches.AnyObject as UITouch);
+        }
+
+        public override void TouchesEnded(NSSet touches, UIEvent evt)
+        {
+            base.TouchesEnded(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+        }
+
+
+        public override void TouchesMoved(NSSet touches, UIEvent evt)
+        {
+            base.TouchesMoved(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+
+        }
+
+        public override void TouchesCancelled(NSSet touches, UIEvent evt)
+        {
+            base.TouchesCancelled(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+        }
+
+
+        private void AnimateStart(UITouch touch)
+        {
+            AnimateBackgroundFadeIn(touch);
+            AnimateRipple(touch);
+
+            _isStarted = true;
+        }
+
+
+        private void AnimateComplete(UITouch touch)
+        {
+            if (_isStarted)
+            {
+                AnimateBackgroundFadeOut(touch);
+            }
+        }
+
+
+        private void AnimateBackgroundFadeIn(UITouch touch)
+        {
+            var view = _touchView;
+
+            SetupAnimationLayer(_backgroundLayer, view, 3);
+
+            _backgroundLayer.RemoveAllAnimations();
+            UIView.Animate(0.8, () =>
+            {
+                _backgroundLayer.AddAnimation(_backgroundFadeInAnimation, "backgroundFadeInAnimation");
+            });
+        }
+
+        private void AnimateBackgroundFadeOut(UITouch touch)
+        {
+            var view = _touchView;
+
+            SetupAnimationLayer(_backgroundLayer, view, 3);
+
+            _backgroundLayer.RemoveAllAnimations();
+            UIView.Animate(0.8, () =>
+            {
+                _backgroundLayer.AddAnimation(_backgroundFadeOutAnimation, "backgroundFadeOutAnimation");
+            });
+        }
+
+        private void AnimateRipple(UITouch touch)
+        {
+            var view = _touchView;
+
+            var location = touch.LocationInView(view);
+            var startPath = UIBezierPath.FromArc(location, 8f, 0, 360f, true);
+            var endPath = UIBezierPath.FromArc(location, view.Frame.Width - 12, 0, 360f, true);
+
+            SetupAnimationLayer(_rippleLayer, view, 4);
+
+            _rippleAnimation.From = FromObject(startPath.CGPath);
+            _rippleAnimation.To = FromObject(endPath.CGPath);
+            UIView.Animate(0.3, () =>
+            {
+                _rippleLayer.AddAnimation(_rippleAnimation, "rippleAnimation");
+                _rippleLayer.AddAnimation(_fadeAnimation, "rippleFadeAnim");
+            });
+        }
+
+
+        /// <summary>
+        /// Sets the <paramref name="layer"/>'s bounding frame based on the 
+        /// View this gesture recognizer is attached to.
+        /// </summary>
+        /// <param name="layer">Layer.</param>
+        /// <param name="view">View.</param>
+        private void SetupAnimationLayer(CALayer layer, UIView view, int indexToInsertLayer)
+        {
+            if (view is MaterialCardRenderer)
+                layer.Frame = new CGRect(0, 0, view.Frame.Width, view.Frame.Height);
+            else
+                layer.Frame = new CGRect(6, 6, view.Frame.Width - 12, view.Frame.Height - 12);
+
+            layer.CornerRadius = view.Layer.CornerRadius;
+            view.Layer.InsertSublayer(layer, indexToInsertLayer);
+
+        }
+    }
+}

--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -47,6 +47,8 @@ namespace XF.Material.iOS.Renderers
             {
                 _materialButton.WidthRequest = 64;
             }
+
+            UpdateTextSizing();
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
@@ -267,10 +269,19 @@ namespace XF.Material.iOS.Renderers
         {
             if (_withIcon)
             {
-                using (var image = UIImage.FromFile(_materialButton.Image.File))
+                UIImage image = null; 
+
+                try
                 {
+                    image = UIImage.FromFile(_materialButton.Image.File);
+
+                    if (image == null)
+                        image = UIImage.FromBundle(_materialButton.Image.File);
+
+
                     UIGraphics.BeginImageContextWithOptions(new CGSize(18, 18), false, 0f);
-                    image.Draw(new CGRect(0, 0, 18, 18));
+                    if (image != null)
+                        image.Draw(new CGRect(0, 0, 18, 18));
 
                     using (var newImage = UIGraphics.GetImageFromCurrentImageContext())
                     {
@@ -278,11 +289,23 @@ namespace XF.Material.iOS.Renderers
 
                         this.Control.SetImage(newImage, UIControlState.Normal);
                         this.Control.SetImage(newImage, UIControlState.Disabled);
-                        this.Control.TitleEdgeInsets = new UIEdgeInsets(0f, 0f, 0f, 0f);
-                        this.Control.ImageEdgeInsets = new UIEdgeInsets(0f, -6f, 0f, 0f);
+
+                        this.Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+                        this.Control.ImageEdgeInsets = new UIEdgeInsets(0f, 0f, 0f, 0f);
                         this.Control.TintColor = _materialButton.TextColor.ToUIColor();
                     }
                 }
+                finally
+                {
+                    if (image != null)
+                        image.Dispose();
+                    image = null;
+                }
+            }
+            else
+            {
+                this.Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+                this.Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
             }
         }
 
@@ -332,10 +355,42 @@ namespace XF.Material.iOS.Renderers
             {
                 this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 22f, 10f, 22f);
             }
-            else if (_materialButton.ButtonType == MaterialButtonType.Text)
+            else if (_materialButton.ButtonType == MaterialButtonType.Text && _withIcon)
+            {
+                this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 18f, 10f, 22f);
+            }
+            else if (_materialButton.ButtonType == MaterialButtonType.Text && !_withIcon)
             {
                 this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 14f, 10f, 14f);
             }
+        }
+
+        private void UpdateTextSizing()
+        {
+            if (String.IsNullOrEmpty(_materialButton.Text) || !_withIcon)
+            {
+                this.Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+                return;
+            }
+
+            // We have to set the button title insets to make the button look
+            // like Android's material buttons. (icon on left, text is centralized)
+            //
+            NSString textToMeasure = (NSString)(_materialButton.Text ?? "");
+
+            CGRect labelRect = textToMeasure.GetBoundingRect(
+                new CGSize(this.Frame.Width - 40, nfloat.MaxValue),
+                NSStringDrawingOptions.UsesLineFragmentOrigin,
+                new UIStringAttributes() { Font = this.Control.Font },
+                new NSStringDrawingContext()
+            );
+
+            float textWidth = (float)labelRect.Size.Width;
+            float buttonWidth = (float)this.Control.Frame.Width;
+
+            float inset = (buttonWidth - textWidth) / 2 - 28;
+            this.Control.TitleEdgeInsets = new UIEdgeInsets(0, inset, 0,  -40);
+
         }
 
         private void UpdateCornerRadius()

--- a/XF.Material/XF.Material.iOS/XF.Material.iOS.csproj
+++ b/XF.Material/XF.Material.iOS/XF.Material.iOS.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Renderers\MaterialMenuRenderer.cs" />
     <Compile Include="Renderers\MaterialNavigationPageRenderer.cs" />
     <Compile Include="Utility\MaterialUtility.cs" />
+    <Compile Include="GestureRecognizers\MaterialRippleGestureRecognizer.cs" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\xf_error%402x.png" />
@@ -162,6 +163,9 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\xf_arrow_dropdown%403x.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="GestureRecognizers\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
To enable, set IsClickable on MaterialCard element to "true".

Unlike my previous issue raised, this enhancement doesn't add the OnClicked/Command properties. It simply just makes the MaterialCard clickable with a material Ripple effect. Works on Android and iOS.

