### PR TITLE
Added Material Ripple effect, and fixed MaterialButtonRenderer for iOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,11 +20,6 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Xamarin.Forms library for Xamarin.Android and Xamarin.iOS to implement [Google
     - [Retrieving a Material Resource](#retrieving-a-material-resource)
   - [Changing the Status Bar Color](#changing-the-status-bar-color)
 - [Android Compatibility Issues](#android-compatibility-issues)
-- [Libraries Used](#libraries-used)
+- [Thanks and Appreciation](#thanks-and-appreciation)
 
 ## Getting Started
 1. Download the current version through [NuGet](https://www.nuget.org/packages/XF.Material) and install it in your Xamarin.Forms projects.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <img src="images/xf.material_logo.png" width="112" />
 
-# XF.Material Library [![NuGet](https://img.shields.io/badge/version-1.3.0.10-orange.svg?style=flat)](https://github.com/contrix09/XF-Material-Library/blob/master/RELEASE_NOTES.md) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
+# XF.Material Library [![NuGet](https://img.shields.io/badge/version-1.3.1.1-orange.svg?style=flat)](https://github.com/contrix09/XF-Material-Library/blob/master/RELEASE_NOTES.md) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
 
 A Xamarin.Forms library for Xamarin.Android and Xamarin.iOS to implement [Google's Material Design](https://material.io/design).
 
@@ -1222,8 +1222,12 @@ If targeted below Android 5.0, the following issues can be seen:
 - On Android 4.2 (Jellybean), `MaterialButton` is larger. Explanation is provided in this [issue](https://github.com/contrix09/XF-Material-Library/issues/2#issuecomment-417819032).
 - Letter spacing of typescale effects won't work for devices running below Android 5.0 (Lollipop). The API for setting the letter spacing was added in Android 5.0.
 
-## Libraries Used
+## Thanks and Appreciation
 Special thanks to the following libraries I used for this project:
 - [Rg.Plugins.Popup](https://github.com/rotorgames/Rg.Plugins.Popup)
 - [LottieXamarin](https://github.com/martijn00/LottieXamarin)
 - [Xamarin.Essentials](https://github.com/xamarin/Essentials)
+
+Coffee supports this library, help the devs by giving them coffee:
+
+[![Donate](https://img.shields.io/badge/Give%20Coffee-Donate-orange.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K4HS649SFADTS&source=url)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+##### 1.3.1.1
+- Fixed issue [35](https://github.com/contrix09/XF-Material-Library/issues/35).
+- Fixed issue [38](https://github.com/contrix09/XF-Material-Library/issues/38).
+- Fixed issue [53](https://github.com/contrix09/XF-Material-Library/issues/53).
+- Fixed issue [58](https://github.com/contrix09/XF-Material-Library/issues/58).
+
 ##### 1.3.1.0
 - Fixed issue [50](https://github.com/contrix09/XF-Material-Library/issues/50).
 

--- a/XF.Material-Azure.nuspec
+++ b/XF.Material-Azure.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XF.Material</id>
     <title>XF.Material Library</title>
-    <version>1.3.1.0</version>
+    <version>1.3.1.1</version>
     <authors>Dustin Catap</authors>
     <owners>Dustin Catap</owners>
     <projectUrl>https://github.com/contrix09/XF-Material-Library</projectUrl>

--- a/XF.Material.nuspec
+++ b/XF.Material.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XF.Material</id>
     <title>XF.Material Library</title>
-    <version>1.3.1.0</version>
+    <version>1.3.1.1</version>
     <authors>Dustin Catap</authors>
     <owners>Dustin Catap</owners>
     <projectUrl>https://github.com/contrix09/XF-Material-Library</projectUrl>

--- a/XF.Material/XF.Material.Droid/Renderers/MaterialDrawableHelper.cs
+++ b/XF.Material/XF.Material.Droid/Renderers/MaterialDrawableHelper.cs
@@ -86,10 +86,7 @@ namespace XF.Material.Droid.Renderers
 
         public void UpdateDrawable()
         {
-            using (var drawable = this.GetDrawable())
-            {
-                _aView.Background = drawable;
-            }
+            _aView.Background = this.GetDrawable();
 
             this.UpdateElevation();
         }

--- a/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml
+++ b/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml
@@ -3,6 +3,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:fx="clr-namespace:XF.Material.Forms.Effects"
+    xmlns:mat="clr-namespace:XF.Material.Forms.UI"
     Padding="0">
     <ContentView.Resources>
         <ResourceDictionary>
@@ -73,15 +74,14 @@
             <Frame x:Name="ChipImageContainer"
                 Margin="6,0,-4,0"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="Transparent"
                 CornerRadius="12"
                 HasShadow="False"
                 HeightRequest="24"
                 IsVisible="False"
                 VerticalOptions="Center"
                 WidthRequest="24">
-                <Image x:Name="ChipImage"
-                    Aspect="AspectFit"
+                <mat:MaterialIcon x:Name="ChipImage"
                     HeightRequest="24"
                     WidthRequest="24" />
             </Frame>
@@ -102,7 +102,7 @@
                     </DataTrigger>
                 </Label.Triggers>
             </Label>
-            <Image x:Name="ChipActionImage"
+            <mat:MaterialIcon x:Name="ChipActionImage"
                 IsVisible="False"
                 Style="{StaticResource Material.Chip.ActionImage}" />
         </StackLayout>

--- a/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml.cs
@@ -9,69 +9,77 @@ namespace XF.Material.Forms.UI
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class MaterialChip : ContentView
     {
+        public static readonly BindableProperty ActionImageProperty = BindableProperty.Create(nameof(ActionImage), typeof(ImageSource), typeof(MaterialChip), default(ImageSource));
+        public static readonly BindableProperty ActionImageTappedCommandProperty = BindableProperty.Create(nameof(ActionImageTappedCommand), typeof(ICommand), typeof(MaterialChip), default(Command));
+        public static readonly BindableProperty ActionImageTintColorProperty = BindableProperty.Create(nameof(ActionImageTintColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(MaterialChip), default(string));
+        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(ImageSource), typeof(MaterialChip), default(ImageSource));
+        public static readonly BindableProperty ImageTintColorProperty = BindableProperty.Create(nameof(ImageTintColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(MaterialChip), Color.FromHex("#DE000000"));
+        public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialChip), string.Empty);
+
         private bool _canExecute;
+
+        public MaterialChip()
+        {
+            this.InitializeComponent();
+        }
 
         public event EventHandler ActionImageTapped;
 
-        public static readonly new BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialChip), default(Color));
-
-        public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(string), string.Empty);
-
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Color), Color.FromHex("#DE000000"));
-
-        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(ImageSource), typeof(ImageSource), default(ImageSource));
-
-        public static readonly BindableProperty ActionImageProperty = BindableProperty.Create(nameof(ActionImage), typeof(ImageSource), typeof(ImageSource), default(ImageSource));
-
-        public static readonly BindableProperty ActionImageTappedCommandProperty = BindableProperty.Create(nameof(ActionImageTappedCommand), typeof(ICommand), typeof(ICommand), default(Command));
-
-        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(string), default(string));
-
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
-        }
-
-        public string Text
-        {
-            get => (string)GetValue(TextProperty);
-            set => SetValue(TextProperty, value);
-        }
-
-        public Color TextColor
-        {
-            get => (Color)GetValue(TextColorProperty);
-            set => SetValue(TextColorProperty, value);
-        }
-
-        public string FontFamily
-        {
-            get => (string)GetValue(FontFamilyProperty);
-            set => SetValue(FontFamilyProperty, value);
-        }
-
-        public ImageSource Image
-        {
-            get => (ImageSource)GetValue(ImageProperty);
-            set => SetValue(ImageProperty, value);
-        }
-
         public ImageSource ActionImage
         {
-            get => (ImageSource)GetValue(ActionImageProperty);
-            set => SetValue(ActionImageProperty, value);
+            get => (ImageSource)this.GetValue(ActionImageProperty);
+            set => this.SetValue(ActionImageProperty, value);
         }
 
         public Command ActionImageTappedCommand
         {
-            get => (Command)GetValue(ActionImageTappedCommandProperty);
-            set => SetValue(ActionImageTappedCommandProperty, value);
+            get => (Command)this.GetValue(ActionImageTappedCommandProperty);
+            set => this.SetValue(ActionImageTappedCommandProperty, value);
         }
 
-        public MaterialChip()
+        public Color ActionImageTintColor
         {
-            InitializeComponent();
+            get => (Color)this.GetValue(ActionImageTintColorProperty);
+            set => this.SetValue(ActionImageTintColorProperty, value);
+        }
+
+        public new Color BackgroundColor
+        {
+            get => (Color)this.GetValue(BackgroundColorProperty);
+            set => this.SetValue(BackgroundColorProperty, value);
+        }
+
+        public string FontFamily
+        {
+            get => (string)this.GetValue(FontFamilyProperty);
+            set => this.SetValue(FontFamilyProperty, value);
+        }
+
+        public ImageSource Image
+        {
+            get => (ImageSource)this.GetValue(ImageProperty);
+            set => this.SetValue(ImageProperty, value);
+        }
+
+        public Color ImageTintColor
+        {
+            get => (Color)this.GetValue(ImageTintColorProperty);
+            set => this.SetValue(ImageTintColorProperty, value);
+        }
+
+        public string Text
+        {
+            get => (string)this.GetValue(TextProperty);
+            set => this.SetValue(TextProperty, value);
+        }
+
+        public Color TextColor
+        {
+            get => (Color)this.GetValue(TextColorProperty);
+            set => this.SetValue(TextColorProperty, value);
         }
 
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
@@ -80,7 +88,6 @@ namespace XF.Material.Forms.UI
             {
                 ChipContainer.BackgroundColor = this.BackgroundColor;
             }
-
             else
             {
                 base.OnPropertyChanged(propertyName);
@@ -90,22 +97,28 @@ namespace XF.Material.Forms.UI
                     ChipLabel.Text = this.Text;
                 }
 
+                if (propertyName == nameof(this.ActionImageTintColor))
+                {
+                    ChipActionImage.TintColor = this.ActionImageTintColor;
+                }
+
+                if (propertyName == nameof(this.ImageTintColor))
+                {
+                    ChipImage.TintColor = this.ImageTintColor;
+                }
                 else if (propertyName == nameof(this.TextColor))
                 {
                     ChipLabel.TextColor = this.TextColor;
                 }
-
                 else if (propertyName == nameof(this.FontFamily))
                 {
                     ChipLabel.FontFamily = this.FontFamily;
                 }
-
                 else if (propertyName == nameof(this.Image))
                 {
                     ChipImageContainer.IsVisible = this.Image != null;
                     ChipImage.Source = this.Image;
                 }
-
                 else if (propertyName == nameof(this.ActionImage))
                 {
                     ChipActionImage.Source = this.ActionImage;
@@ -115,7 +128,6 @@ namespace XF.Material.Forms.UI
                     {
                         ChipActionImage.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(this.ActionImageTapHandled, () => !_canExecute), NumberOfTapsRequired = 1 });
                     }
-
                     else if (this.ActionImage == null)
                     {
                         ChipActionImage.GestureRecognizers.Clear();

--- a/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
@@ -74,7 +74,6 @@ namespace XF.Material.Forms.UI
         private readonly Easing animationCurve = Easing.SinOut;
         private bool _counterEnabled;
         private bool _wasFocused;
-        private bool _rowHeightWasSet;
 
         /// <summary>
         /// Initializes a new instance of <see cref="MaterialTextField"/>.
@@ -365,6 +364,11 @@ namespace XF.Material.Forms.UI
                 entry.PropertyChanged -= this.Entry_PropertyChanged;
             }
         }
+
+        /// <summary>
+        /// Requests to focus this text field.
+        /// </summary>
+        public new void Focus() => entry.Focus();
 
         protected override void LayoutChildren(double x, double y, double width, double height)
         {
@@ -872,7 +876,6 @@ namespace XF.Material.Forms.UI
                 { nameof(this.FloatingPlaceholderEnabled), () => this.OnFloatingPlaceholderEnabledChanged(this.FloatingPlaceholderEnabled) },
             };
         }
-
         private void UpdateCounter()
         {
             if (_counterEnabled)

--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -346,6 +346,11 @@ namespace XF.Material.iOS.Renderers
 
         private void UpdateLayerFrame()
         {
+            if(this.Control == null)
+            {
+                return;
+            }
+
             var width = this.Control.Frame.Width - 12;
             var height = this.Control.Frame.Height - 12;
 


### PR DESCRIPTION
1. Added Material Ripple effect for MaterialCard for iOS and Android. Enable it by setting IsClickable to "true". Developers will still need to add a TapGestureRecognizer to handle events.

2. Fixed MaterialButtonRender for iOS to 
   a. Allow devs to load images from Assets.xcassets
   b. Prevent the app from crashing if the image is not found
   c. Layout the text and icon to make it look like Android's button for cross-platform consistency (especially for those buttons stretched horizontally).

**iOS Before Fix:**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterialButtonRender-iOS%20Before%20Fix.png)

**iOS After Fix:**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterlalButtonRenderer-iOS%20After%20Fix.png)

**Android Layout**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterialButtonRenderer-Android.png)