### PR TITLE
Added Material Ripple effect, and fixed MaterialButtonRenderer for iOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,11 +20,6 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]

--- a/MaterialMvvmSample/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
+++ b/MaterialMvvmSample/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
     <NuGetPackageImportStamp>

--- a/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
+++ b/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <local:BaseMainView x:Class="MaterialMvvmSample.Views.MainView"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -72,6 +72,7 @@
                             <material:MaterialCard Margin="4"
                                 Padding="16,8,4,8"
                                 Elevation="2"
+                                IsClickable="true"
                                 IsClippedToBounds="False">
                                 <View.GestureRecognizers>
                                     <TapGestureRecognizer Command="{Binding Source={x:Reference Root}, Path=BindingContext.JobSelectedCommand}"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Xamarin.Forms library for Xamarin.Android and Xamarin.iOS to implement [Google
     - [Retrieving a Material Resource](#retrieving-a-material-resource)
   - [Changing the Status Bar Color](#changing-the-status-bar-color)
 - [Android Compatibility Issues](#android-compatibility-issues)
-- [Libraries Used](#libraries-used)
+- [Thanks and Appreciation](#thanks-and-appreciation)
 
 ## Getting Started
 1. Download the current version through [NuGet](https://www.nuget.org/packages/XF.Material) and install it in your Xamarin.Forms projects.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <img src="images/xf.material_logo.png" width="112" />
 
-# XF.Material Library [![NuGet](https://img.shields.io/badge/version-1.3.0.10-orange.svg?style=flat)](https://github.com/contrix09/XF-Material-Library/blob/master/RELEASE_NOTES.md) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
+# XF.Material Library [![NuGet](https://img.shields.io/badge/version-1.3.1.1-orange.svg?style=flat)](https://github.com/contrix09/XF-Material-Library/blob/master/RELEASE_NOTES.md) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
 
 A Xamarin.Forms library for Xamarin.Android and Xamarin.iOS to implement [Google's Material Design](https://material.io/design).
 
@@ -1222,8 +1222,12 @@ If targeted below Android 5.0, the following issues can be seen:
 - On Android 4.2 (Jellybean), `MaterialButton` is larger. Explanation is provided in this [issue](https://github.com/contrix09/XF-Material-Library/issues/2#issuecomment-417819032).
 - Letter spacing of typescale effects won't work for devices running below Android 5.0 (Lollipop). The API for setting the letter spacing was added in Android 5.0.
 
-## Libraries Used
+## Thanks and Appreciation
 Special thanks to the following libraries I used for this project:
 - [Rg.Plugins.Popup](https://github.com/rotorgames/Rg.Plugins.Popup)
 - [LottieXamarin](https://github.com/martijn00/LottieXamarin)
 - [Xamarin.Essentials](https://github.com/xamarin/Essentials)
+
+Coffee supports this library, help the devs by giving them coffee:
+
+[![Donate](https://img.shields.io/badge/Give%20Coffee-Donate-orange.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=K4HS649SFADTS&source=url)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+##### 1.3.1.1
+- Fixed issue [35](https://github.com/contrix09/XF-Material-Library/issues/35).
+- Fixed issue [38](https://github.com/contrix09/XF-Material-Library/issues/38).
+- Fixed issue [53](https://github.com/contrix09/XF-Material-Library/issues/53).
+- Fixed issue [58](https://github.com/contrix09/XF-Material-Library/issues/58).
+
 ##### 1.3.1.0
 - Fixed issue [50](https://github.com/contrix09/XF-Material-Library/issues/50).
 

--- a/XF.Material-Azure.nuspec
+++ b/XF.Material-Azure.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XF.Material</id>
     <title>XF.Material Library</title>
-    <version>1.3.1.0</version>
+    <version>1.3.1.1</version>
     <authors>Dustin Catap</authors>
     <owners>Dustin Catap</owners>
     <projectUrl>https://github.com/contrix09/XF-Material-Library</projectUrl>

--- a/XF.Material.nuspec
+++ b/XF.Material.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>XF.Material</id>
     <title>XF.Material Library</title>
-    <version>1.3.1.0</version>
+    <version>1.3.1.1</version>
     <authors>Dustin Catap</authors>
     <owners>Dustin Catap</owners>
     <projectUrl>https://github.com/contrix09/XF-Material-Library</projectUrl>

--- a/XF.Material/XF.Material.Droid/Renderers/MaterialCardRenderer.cs
+++ b/XF.Material/XF.Material.Droid/Renderers/MaterialCardRenderer.cs
@@ -1,19 +1,46 @@
-﻿using Android.Content;
+﻿using Android.App;
+using Android.Content;
 using Android.OS;
+using Android.Util;
+using Android.Views;
 using System.ComponentModel;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 using XF.Material.Droid.Renderers;
 using XF.Material.Forms.UI;
+using static Android.Views.View;
 
 [assembly: ExportRenderer(typeof(MaterialCard), typeof(MaterialCardRenderer))]
 namespace XF.Material.Droid.Renderers
 {
-    public class MaterialCardRenderer : Xamarin.Forms.Platform.Android.AppCompat.FrameRenderer
+    public class MaterialCardRenderer : Xamarin.Forms.Platform.Android.AppCompat.FrameRenderer, IOnTouchListener
     {
         private MaterialCard _materialCard;
 
         public MaterialCardRenderer(Context context) : base(context) { }
+
+        public bool OnTouch(Android.Views.View v, MotionEvent e)
+        {
+            if (this._materialCard.GestureRecognizers.Count > 0)
+            {
+                if (this.Control.Foreground != null)
+                {
+                    if (e.Action == MotionEventActions.Down)
+                    {
+                        this.Control.Foreground.SetHotspot(e.GetX(), e.GetY());
+                        this.Control.Pressed = true;
+                    }
+                    else if (e.Action == MotionEventActions.Up ||
+                        e.Action == MotionEventActions.Cancel ||
+                        e.Action == MotionEventActions.Outside)
+                    {
+                        this.Control.Pressed = false;
+                    }
+                }
+            }
+            return false;
+        }
+
 
         protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
         {
@@ -33,6 +60,9 @@ namespace XF.Material.Droid.Renderers
                 #endregion
 
                 this.Control.Elevate(_materialCard.Elevation);
+
+                this.SetClickable();
+                this.Control.SetOnTouchListener(this);
             }
         }
 
@@ -44,6 +74,27 @@ namespace XF.Material.Droid.Renderers
             {
                 this.Control.Elevate(_materialCard.Elevation);
             }
+
+            if (e?.PropertyName == nameof(MaterialCard.IsClickable))
+            {
+                this.SetClickable();
+
+            }
+        }
+
+        protected void SetClickable()
+        {
+            bool clickable = _materialCard.IsClickable;
+            if (clickable && this.Control.Foreground == null)
+            {
+                TypedValue outValue = new TypedValue();
+                this.Context.Theme.ResolveAttribute(
+                    Resource.Attribute.selectableItemBackground, outValue, true);
+                this.Control.Foreground = this.Context.GetDrawable(outValue.ResourceId);
+            }
+
+            this.Control.Focusable = clickable;
+            this.Control.Clickable = clickable;
         }
     }
 }

--- a/XF.Material/XF.Material.Droid/Renderers/MaterialDrawableHelper.cs
+++ b/XF.Material/XF.Material.Droid/Renderers/MaterialDrawableHelper.cs
@@ -86,10 +86,7 @@ namespace XF.Material.Droid.Renderers
 
         public void UpdateDrawable()
         {
-            using (var drawable = this.GetDrawable())
-            {
-                _aView.Background = drawable;
-            }
+            _aView.Background = this.GetDrawable();
 
             this.UpdateElevation();
         }

--- a/XF.Material/XF.Material.Droid/XF.Material.Droid.csproj
+++ b/XF.Material/XF.Material.Droid/XF.Material.Droid.csproj
@@ -15,7 +15,6 @@
     <FileAlignment>512</FileAlignment>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/XF.Material/XF.Material.Forms/UI/MaterialCard.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialCard.cs
@@ -15,12 +15,26 @@ namespace XF.Material.Forms.UI
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(int), typeof(MaterialCard), 1);
 
         /// <summary>
+        /// Backing field for the bindable property <see cref="IsClickable"/>.
+        /// </summary>
+        public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(MaterialCard), false);
+
+        /// <summary>
         /// Gets or sets the virtual distance along the z-axis for emphasis.
         /// </summary>
         public int Elevation
         {
             get => (int)this.GetValue(ElevationProperty);
             set => this.SetValue(ElevationProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the flag indicating of the card is clickable with a ripple effect.
+        /// </summary>
+        public bool IsClickable
+        {
+            get => (bool)this.GetValue(IsClickableProperty);
+            set => this.SetValue(IsClickableProperty, value);
         }
 
         /// <summary>

--- a/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml
+++ b/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml
@@ -3,6 +3,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:fx="clr-namespace:XF.Material.Forms.Effects"
+    xmlns:mat="clr-namespace:XF.Material.Forms.UI"
     Padding="0">
     <ContentView.Resources>
         <ResourceDictionary>
@@ -73,15 +74,14 @@
             <Frame x:Name="ChipImageContainer"
                 Margin="6,0,-4,0"
                 Padding="0"
-                BackgroundColor="White"
+                BackgroundColor="Transparent"
                 CornerRadius="12"
                 HasShadow="False"
                 HeightRequest="24"
                 IsVisible="False"
                 VerticalOptions="Center"
                 WidthRequest="24">
-                <Image x:Name="ChipImage"
-                    Aspect="AspectFit"
+                <mat:MaterialIcon x:Name="ChipImage"
                     HeightRequest="24"
                     WidthRequest="24" />
             </Frame>
@@ -102,7 +102,7 @@
                     </DataTrigger>
                 </Label.Triggers>
             </Label>
-            <Image x:Name="ChipActionImage"
+            <mat:MaterialIcon x:Name="ChipActionImage"
                 IsVisible="False"
                 Style="{StaticResource Material.Chip.ActionImage}" />
         </StackLayout>

--- a/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialChip.xaml.cs
@@ -9,69 +9,77 @@ namespace XF.Material.Forms.UI
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class MaterialChip : ContentView
     {
+        public static readonly BindableProperty ActionImageProperty = BindableProperty.Create(nameof(ActionImage), typeof(ImageSource), typeof(MaterialChip), default(ImageSource));
+        public static readonly BindableProperty ActionImageTappedCommandProperty = BindableProperty.Create(nameof(ActionImageTappedCommand), typeof(ICommand), typeof(MaterialChip), default(Command));
+        public static readonly BindableProperty ActionImageTintColorProperty = BindableProperty.Create(nameof(ActionImageTintColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(MaterialChip), default(string));
+        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(ImageSource), typeof(MaterialChip), default(ImageSource));
+        public static readonly BindableProperty ImageTintColorProperty = BindableProperty.Create(nameof(ImageTintColor), typeof(Color), typeof(MaterialChip), default(Color));
+        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(MaterialChip), Color.FromHex("#DE000000"));
+        public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialChip), string.Empty);
+
         private bool _canExecute;
+
+        public MaterialChip()
+        {
+            this.InitializeComponent();
+        }
 
         public event EventHandler ActionImageTapped;
 
-        public static readonly new BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialChip), default(Color));
-
-        public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(string), string.Empty);
-
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(Color), Color.FromHex("#DE000000"));
-
-        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(ImageSource), typeof(ImageSource), default(ImageSource));
-
-        public static readonly BindableProperty ActionImageProperty = BindableProperty.Create(nameof(ActionImage), typeof(ImageSource), typeof(ImageSource), default(ImageSource));
-
-        public static readonly BindableProperty ActionImageTappedCommandProperty = BindableProperty.Create(nameof(ActionImageTappedCommand), typeof(ICommand), typeof(ICommand), default(Command));
-
-        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(nameof(FontFamily), typeof(string), typeof(string), default(string));
-
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
-        }
-
-        public string Text
-        {
-            get => (string)GetValue(TextProperty);
-            set => SetValue(TextProperty, value);
-        }
-
-        public Color TextColor
-        {
-            get => (Color)GetValue(TextColorProperty);
-            set => SetValue(TextColorProperty, value);
-        }
-
-        public string FontFamily
-        {
-            get => (string)GetValue(FontFamilyProperty);
-            set => SetValue(FontFamilyProperty, value);
-        }
-
-        public ImageSource Image
-        {
-            get => (ImageSource)GetValue(ImageProperty);
-            set => SetValue(ImageProperty, value);
-        }
-
         public ImageSource ActionImage
         {
-            get => (ImageSource)GetValue(ActionImageProperty);
-            set => SetValue(ActionImageProperty, value);
+            get => (ImageSource)this.GetValue(ActionImageProperty);
+            set => this.SetValue(ActionImageProperty, value);
         }
 
         public Command ActionImageTappedCommand
         {
-            get => (Command)GetValue(ActionImageTappedCommandProperty);
-            set => SetValue(ActionImageTappedCommandProperty, value);
+            get => (Command)this.GetValue(ActionImageTappedCommandProperty);
+            set => this.SetValue(ActionImageTappedCommandProperty, value);
         }
 
-        public MaterialChip()
+        public Color ActionImageTintColor
         {
-            InitializeComponent();
+            get => (Color)this.GetValue(ActionImageTintColorProperty);
+            set => this.SetValue(ActionImageTintColorProperty, value);
+        }
+
+        public new Color BackgroundColor
+        {
+            get => (Color)this.GetValue(BackgroundColorProperty);
+            set => this.SetValue(BackgroundColorProperty, value);
+        }
+
+        public string FontFamily
+        {
+            get => (string)this.GetValue(FontFamilyProperty);
+            set => this.SetValue(FontFamilyProperty, value);
+        }
+
+        public ImageSource Image
+        {
+            get => (ImageSource)this.GetValue(ImageProperty);
+            set => this.SetValue(ImageProperty, value);
+        }
+
+        public Color ImageTintColor
+        {
+            get => (Color)this.GetValue(ImageTintColorProperty);
+            set => this.SetValue(ImageTintColorProperty, value);
+        }
+
+        public string Text
+        {
+            get => (string)this.GetValue(TextProperty);
+            set => this.SetValue(TextProperty, value);
+        }
+
+        public Color TextColor
+        {
+            get => (Color)this.GetValue(TextColorProperty);
+            set => this.SetValue(TextColorProperty, value);
         }
 
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
@@ -80,7 +88,6 @@ namespace XF.Material.Forms.UI
             {
                 ChipContainer.BackgroundColor = this.BackgroundColor;
             }
-
             else
             {
                 base.OnPropertyChanged(propertyName);
@@ -90,22 +97,28 @@ namespace XF.Material.Forms.UI
                     ChipLabel.Text = this.Text;
                 }
 
+                if (propertyName == nameof(this.ActionImageTintColor))
+                {
+                    ChipActionImage.TintColor = this.ActionImageTintColor;
+                }
+
+                if (propertyName == nameof(this.ImageTintColor))
+                {
+                    ChipImage.TintColor = this.ImageTintColor;
+                }
                 else if (propertyName == nameof(this.TextColor))
                 {
                     ChipLabel.TextColor = this.TextColor;
                 }
-
                 else if (propertyName == nameof(this.FontFamily))
                 {
                     ChipLabel.FontFamily = this.FontFamily;
                 }
-
                 else if (propertyName == nameof(this.Image))
                 {
                     ChipImageContainer.IsVisible = this.Image != null;
                     ChipImage.Source = this.Image;
                 }
-
                 else if (propertyName == nameof(this.ActionImage))
                 {
                     ChipActionImage.Source = this.ActionImage;
@@ -115,7 +128,6 @@ namespace XF.Material.Forms.UI
                     {
                         ChipActionImage.GestureRecognizers.Add(new TapGestureRecognizer { Command = new Command(this.ActionImageTapHandled, () => !_canExecute), NumberOfTapsRequired = 1 });
                     }
-
                     else if (this.ActionImage == null)
                     {
                         ChipActionImage.GestureRecognizers.Clear();

--- a/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
@@ -74,7 +74,6 @@ namespace XF.Material.Forms.UI
         private readonly Easing animationCurve = Easing.SinOut;
         private bool _counterEnabled;
         private bool _wasFocused;
-        private bool _rowHeightWasSet;
 
         /// <summary>
         /// Initializes a new instance of <see cref="MaterialTextField"/>.
@@ -365,6 +364,11 @@ namespace XF.Material.Forms.UI
                 entry.PropertyChanged -= this.Entry_PropertyChanged;
             }
         }
+
+        /// <summary>
+        /// Requests to focus this text field.
+        /// </summary>
+        public new void Focus() => entry.Focus();
 
         protected override void LayoutChildren(double x, double y, double width, double height)
         {
@@ -872,7 +876,6 @@ namespace XF.Material.Forms.UI
                 { nameof(this.FloatingPlaceholderEnabled), () => this.OnFloatingPlaceholderEnabledChanged(this.FloatingPlaceholderEnabled) },
             };
         }
-
         private void UpdateCounter()
         {
             if (_counterEnabled)

--- a/XF.Material/XF.Material.iOS/GestureRecognizers/MaterialRippleGestureRecognizer.cs
+++ b/XF.Material/XF.Material.iOS/GestureRecognizers/MaterialRippleGestureRecognizer.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using CoreAnimation;
+using CoreGraphics;
+using Foundation;
+using UIKit;
+using XF.Material.iOS.Renderers;
+
+namespace XF.Material.iOS.GestureRecognizers
+{
+    public class MaterialRippleGestureRecognizer : UITapGestureRecognizer, IUIGestureRecognizerDelegate
+    {
+        private readonly CABasicAnimation _rippleAnimation;
+        private readonly CABasicAnimation _fadeAnimation;
+        private readonly CABasicAnimation _backgroundFadeInAnimation;
+        private readonly CABasicAnimation _backgroundFadeOutAnimation;
+        private readonly CALayer _backgroundLayer;
+        private readonly CAShapeLayer _rippleLayer;
+        private UIView _touchView;
+        private bool _isStarted;
+
+        public MaterialRippleGestureRecognizer(CGColor rippleColor, UIView view)
+        {
+            _rippleAnimation = CABasicAnimation.FromKeyPath("path");
+            _rippleAnimation.Duration = 0.3;
+            _rippleAnimation.FillMode = CAFillMode.Forwards;
+            _rippleAnimation.RemovedOnCompletion = true;
+
+            _fadeAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _fadeAnimation.Duration = 0.3;
+            _fadeAnimation.FillMode = CAFillMode.Forwards;
+            _fadeAnimation.RemovedOnCompletion = true;
+            _fadeAnimation.From = FromObject(0.66f);
+            _fadeAnimation.To = FromObject(0.0f);
+
+            _backgroundFadeInAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _backgroundFadeInAnimation.Duration = 0.3;
+            _backgroundFadeInAnimation.FillMode = CAFillMode.Forwards;
+            _backgroundFadeInAnimation.RemovedOnCompletion = false;
+            _backgroundFadeInAnimation.From = FromObject(0.0f);
+            _backgroundFadeInAnimation.To = FromObject(0.20f);
+
+            _backgroundFadeOutAnimation = CABasicAnimation.FromKeyPath("opacity");
+            _backgroundFadeOutAnimation.Duration = 0.3;
+            _backgroundFadeOutAnimation.FillMode = CAFillMode.Forwards;
+            _backgroundFadeOutAnimation.RemovedOnCompletion = true;
+            _backgroundFadeOutAnimation.From = FromObject(0.20f);
+            _backgroundFadeOutAnimation.To = FromObject(0.0f);
+
+            _rippleLayer = new CAShapeLayer();
+            _rippleLayer.FillColor = rippleColor;
+            _rippleLayer.MasksToBounds = true;
+
+            _backgroundLayer = new CALayer();
+            _backgroundLayer.BackgroundColor = rippleColor;
+            _backgroundLayer.MasksToBounds = true;
+            _backgroundLayer.Opacity = 0;
+
+            _isStarted = false;
+            _touchView = view;
+            Delegate = this;
+        }
+
+        [Export("gestureRecognizer:shouldReceiveTouch:")]
+        public new bool ShouldReceiveTouch(UIGestureRecognizer recognizer, UITouch touch)
+        {
+            if (touch.View is UIButton)
+                return false;
+
+            return true;
+        }
+
+
+        public override void TouchesBegan(NSSet touches, UIEvent evt)
+        {
+            base.TouchesBegan(touches, evt);
+
+            AnimateStart(touches.AnyObject as UITouch);
+        }
+
+        public override void TouchesEnded(NSSet touches, UIEvent evt)
+        {
+            base.TouchesEnded(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+        }
+
+
+        public override void TouchesMoved(NSSet touches, UIEvent evt)
+        {
+            base.TouchesMoved(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+
+        }
+
+        public override void TouchesCancelled(NSSet touches, UIEvent evt)
+        {
+            base.TouchesCancelled(touches, evt);
+
+            AnimateComplete(touches.AnyObject as UITouch);
+        }
+
+
+        private void AnimateStart(UITouch touch)
+        {
+            AnimateBackgroundFadeIn(touch);
+            AnimateRipple(touch);
+
+            _isStarted = true;
+        }
+
+
+        private void AnimateComplete(UITouch touch)
+        {
+            if (_isStarted)
+            {
+                AnimateBackgroundFadeOut(touch);
+            }
+        }
+
+
+        private void AnimateBackgroundFadeIn(UITouch touch)
+        {
+            var view = _touchView;
+
+            SetupAnimationLayer(_backgroundLayer, view, 3);
+
+            _backgroundLayer.RemoveAllAnimations();
+            UIView.Animate(0.8, () =>
+            {
+                _backgroundLayer.AddAnimation(_backgroundFadeInAnimation, "backgroundFadeInAnimation");
+            });
+        }
+
+        private void AnimateBackgroundFadeOut(UITouch touch)
+        {
+            var view = _touchView;
+
+            SetupAnimationLayer(_backgroundLayer, view, 3);
+
+            _backgroundLayer.RemoveAllAnimations();
+            UIView.Animate(0.8, () =>
+            {
+                _backgroundLayer.AddAnimation(_backgroundFadeOutAnimation, "backgroundFadeOutAnimation");
+            });
+        }
+
+        private void AnimateRipple(UITouch touch)
+        {
+            var view = _touchView;
+
+            var location = touch.LocationInView(view);
+            var startPath = UIBezierPath.FromArc(location, 8f, 0, 360f, true);
+            var endPath = UIBezierPath.FromArc(location, view.Frame.Width - 12, 0, 360f, true);
+
+            SetupAnimationLayer(_rippleLayer, view, 4);
+
+            _rippleAnimation.From = FromObject(startPath.CGPath);
+            _rippleAnimation.To = FromObject(endPath.CGPath);
+            UIView.Animate(0.3, () =>
+            {
+                _rippleLayer.AddAnimation(_rippleAnimation, "rippleAnimation");
+                _rippleLayer.AddAnimation(_fadeAnimation, "rippleFadeAnim");
+            });
+        }
+
+
+        /// <summary>
+        /// Sets the <paramref name="layer"/>'s bounding frame based on the 
+        /// View this gesture recognizer is attached to.
+        /// </summary>
+        /// <param name="layer">Layer.</param>
+        /// <param name="view">View.</param>
+        private void SetupAnimationLayer(CALayer layer, UIView view, int indexToInsertLayer)
+        {
+            if (view is MaterialCardRenderer)
+                layer.Frame = new CGRect(0, 0, view.Frame.Width, view.Frame.Height);
+            else
+                layer.Frame = new CGRect(6, 6, view.Frame.Width - 12, view.Frame.Height - 12);
+
+            layer.CornerRadius = view.Layer.CornerRadius;
+            view.Layer.InsertSublayer(layer, indexToInsertLayer);
+
+        }
+    }
+}

--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -346,6 +346,11 @@ namespace XF.Material.iOS.Renderers
 
         private void UpdateLayerFrame()
         {
+            if(this.Control == null)
+            {
+                return;
+            }
+
             var width = this.Control.Frame.Width - 12;
             var height = this.Control.Frame.Height - 12;
 

--- a/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/XF.Material.iOS/Renderers/MaterialButtonRenderer.cs
@@ -47,6 +47,8 @@ namespace XF.Material.iOS.Renderers
             {
                 _materialButton.WidthRequest = 64;
             }
+
+            UpdateTextSizing();
         }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
@@ -267,10 +269,19 @@ namespace XF.Material.iOS.Renderers
         {
             if (_withIcon)
             {
-                using (var image = UIImage.FromFile(_materialButton.Image.File))
+                UIImage image = null; 
+
+                try
                 {
+                    image = UIImage.FromFile(_materialButton.Image.File);
+
+                    if (image == null)
+                        image = UIImage.FromBundle(_materialButton.Image.File);
+
+
                     UIGraphics.BeginImageContextWithOptions(new CGSize(18, 18), false, 0f);
-                    image.Draw(new CGRect(0, 0, 18, 18));
+                    if (image != null)
+                        image.Draw(new CGRect(0, 0, 18, 18));
 
                     using (var newImage = UIGraphics.GetImageFromCurrentImageContext())
                     {
@@ -278,11 +289,23 @@ namespace XF.Material.iOS.Renderers
 
                         this.Control.SetImage(newImage, UIControlState.Normal);
                         this.Control.SetImage(newImage, UIControlState.Disabled);
-                        this.Control.TitleEdgeInsets = new UIEdgeInsets(0f, 0f, 0f, 0f);
-                        this.Control.ImageEdgeInsets = new UIEdgeInsets(0f, -6f, 0f, 0f);
+
+                        this.Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
+                        this.Control.ImageEdgeInsets = new UIEdgeInsets(0f, 0f, 0f, 0f);
                         this.Control.TintColor = _materialButton.TextColor.ToUIColor();
                     }
                 }
+                finally
+                {
+                    if (image != null)
+                        image.Dispose();
+                    image = null;
+                }
+            }
+            else
+            {
+                this.Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+                this.Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
             }
         }
 
@@ -332,10 +355,42 @@ namespace XF.Material.iOS.Renderers
             {
                 this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 22f, 10f, 22f);
             }
-            else if (_materialButton.ButtonType == MaterialButtonType.Text)
+            else if (_materialButton.ButtonType == MaterialButtonType.Text && _withIcon)
+            {
+                this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 18f, 10f, 22f);
+            }
+            else if (_materialButton.ButtonType == MaterialButtonType.Text && !_withIcon)
             {
                 this.Control.ContentEdgeInsets = new UIEdgeInsets(10f, 14f, 10f, 14f);
             }
+        }
+
+        private void UpdateTextSizing()
+        {
+            if (String.IsNullOrEmpty(_materialButton.Text) || !_withIcon)
+            {
+                this.Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
+                return;
+            }
+
+            // We have to set the button title insets to make the button look
+            // like Android's material buttons. (icon on left, text is centralized)
+            //
+            NSString textToMeasure = (NSString)(_materialButton.Text ?? "");
+
+            CGRect labelRect = textToMeasure.GetBoundingRect(
+                new CGSize(this.Frame.Width - 40, nfloat.MaxValue),
+                NSStringDrawingOptions.UsesLineFragmentOrigin,
+                new UIStringAttributes() { Font = this.Control.Font },
+                new NSStringDrawingContext()
+            );
+
+            float textWidth = (float)labelRect.Size.Width;
+            float buttonWidth = (float)this.Control.Frame.Width;
+
+            float inset = (buttonWidth - textWidth) / 2 - 28;
+            this.Control.TitleEdgeInsets = new UIEdgeInsets(0, inset, 0,  -40);
+
         }
 
         private void UpdateCornerRadius()

--- a/XF.Material/XF.Material.iOS/XF.Material.iOS.csproj
+++ b/XF.Material/XF.Material.iOS/XF.Material.iOS.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Renderers\MaterialMenuRenderer.cs" />
     <Compile Include="Renderers\MaterialNavigationPageRenderer.cs" />
     <Compile Include="Utility\MaterialUtility.cs" />
+    <Compile Include="GestureRecognizers\MaterialRippleGestureRecognizer.cs" />
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\xf_error%402x.png" />
@@ -162,6 +163,9 @@
   </ItemGroup>
   <ItemGroup>
     <BundleResource Include="Resources\xf_arrow_dropdown%403x.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="GestureRecognizers\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
1. Added Material Ripple effect for MaterialCard for iOS and Android. Enable it by setting IsClickable to "true". Developers will still need to add a TapGestureRecognizer to handle events.

2. Fixed MaterialButtonRender for iOS to 
   a. Allow devs to load images from Assets.xcassets
   b. Prevent the app from crashing if the image is not found
   c. Layout the text and icon to make it look like Android's button for cross-platform consistency (especially for those buttons stretched horizontally).

**iOS Before Fix:**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterialButtonRender-iOS%20Before%20Fix.png)

**iOS After Fix:**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterlalButtonRenderer-iOS%20After%20Fix.png)

**Android Layout**
![Alt Text](https://github.com/kfc2000/images/raw/master/MaterialButtonRenderer-Android.png)


You can test with this XAML:

            <material:MaterialButton Text="aEdit" Image="ic_edit" />
            <material:MaterialButton Text="bEdit" Image="ic_edit" ButtonType="Flat" />
            <material:MaterialButton Text="cEdit" Image="ic_edit" ButtonType="Outlined" />
            <material:MaterialButton Text="dEdit" Image="ic_edit" ButtonType="Text" />
            <material:MaterialButton Text="aEdit2" />
            <material:MaterialButton Text="bEdit2" ButtonType="Flat" />
            <material:MaterialButton Text="cEdit2" ButtonType="Outlined" />
            <material:MaterialButton Text="dEdit2" ButtonType="Text" />
            <StackLayout Orientation="Horizontal">
                <material:MaterialButton Text="aEdit3" Image="ic_edit" />
                <material:MaterialButton Text="bEdit3" Image="ic_edit" ButtonType="Flat" />
                <material:MaterialButton Text="cEdit3" Image="ic_edit" ButtonType="Outlined" />
                <material:MaterialButton Text="dEdit3" Image="ic_edit" ButtonType="Text" />
            </StackLayout>
            <StackLayout Orientation="Horizontal">
                <material:MaterialButton Text="aEdit4" />
                <material:MaterialButton Text="bEdit4" ButtonType="Flat" />
                <material:MaterialButton Text="cEdit4" ButtonType="Outlined" />
                <material:MaterialButton Text="dEdit4" ButtonType="Text" />
            </StackLayout>

And of course, with a valid icon "ic_edit" placed in Android res/drawables and iOS's Assets.xcassets.
