### PR TITLE
Font Size on Material Entry

### DIFF
--- a/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
+++ b/MaterialMvvmSample/MaterialMvvmSample/Views/MainView.xaml
@@ -156,6 +156,7 @@
                                             TintColor="#2c3e50" />
                 <material:MaterialTextField AlwaysShowUnderline="True"
                                             BackgroundColor="Transparent"
+                                            FontSize="24"
                                             HelperText="*Required"
                                             InputType="Password"
                                             MaxLength="8"

--- a/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/XF.Material.Forms/UI/MaterialTextField.xaml.cs
@@ -82,6 +82,8 @@ namespace XF.Material.Forms.UI
 
         public static readonly BindableProperty UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#99000000"));
 
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(nameof(FontSize), typeof(double), typeof(MaterialTextField), 16.0);
+
         private const double AnimationDuration = 0.35;
         private readonly Dictionary<string, Action> _propertyChangeActions;
         private readonly Easing _animationCurve = Easing.SinOut;
@@ -404,6 +406,15 @@ namespace XF.Material.Forms.UI
             set => this.SetValue(UnderlineColorProperty, value);
         }
 
+        /// <summary>
+        /// Gets or sets the Font Size Of the entry.
+        /// </summary>
+        public double FontSize
+        {
+            get => (double)this.GetValue(FontSizeProperty);
+            set => this.SetValue(FontSizeProperty, value);
+        }
+
         /// <inheritdoc />
         /// <summary>
         /// For internal use only.
@@ -486,10 +497,10 @@ namespace XF.Material.Forms.UI
         private void AnimatePlaceHolder()
         {
             Color tintColor;
-            double startFont = entry.IsFocused ? 16 : 12;
-            double endFOnt = entry.IsFocused ? 12 : 16;
+            double startFont = entry.IsFocused ? this.FontSize : this.FontSize * 0.75;
+            double endFOnt = entry.IsFocused ? this.FontSize * 0.75 : this.FontSize;
             var startY = placeholder.TranslationY;
-            double endY = entry.IsFocused ? -12 : 0;
+            double endY = entry.IsFocused ? -this.FontSize * 0.75 : 0;
 
             if (this.HasError)
             {
@@ -559,8 +570,8 @@ namespace XF.Material.Forms.UI
 
                     if (this.FloatingPlaceholderEnabled)
                     {
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, 16, 12, _animationCurve));
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.TranslationY = v, placeholder.TranslationY, -12, _animationCurve, () =>
+                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, this.FontSize, this.FontSize*0.75, _animationCurve));
+                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.TranslationY = v, placeholder.TranslationY, -this.FontSize * 0.75, _animationCurve, () =>
                         {
                             placeholder.TextColor = this.HasError ? this.ErrorColor : this.TintColor;
                             entry.Opacity = 1;
@@ -576,7 +587,7 @@ namespace XF.Material.Forms.UI
                 return;
             }
 
-            if ((startObject != null && string.IsNullOrEmpty(this.Text) && placeholder.TranslationY == -12) || placeholder.TranslationY == -20)
+            if ((startObject != null && string.IsNullOrEmpty(this.Text) && placeholder.TranslationY == -this.FontSize * 0.75) || placeholder.TranslationY == -20)
             {
                 if (entry.IsFocused)
                 {
@@ -589,7 +600,7 @@ namespace XF.Material.Forms.UI
 
                     if (this.FloatingPlaceholderEnabled)
                     {
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, 12, 16, _animationCurve));
+                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, this.FontSize * 0.75, this.FontSize, _animationCurve));
                         anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.TranslationY = v, placeholder.TranslationY, 0, _animationCurve, () =>
                         {
                             placeholder.TextColor = this.PlaceholderColor;
@@ -930,6 +941,13 @@ namespace XF.Material.Forms.UI
             this.UpdateCounter();
         }
 
+        private void OnFontSizeChanged(double fontSize)
+        {
+            placeholder.FontSize = fontSize;
+            entry.FontSize = fontSize;
+            entry.HeightRequest = entry.FontSize * 1.25;
+        }
+
         private void OnTextColorChanged(Color textColor)
         {
             entry.TextColor = trailingIcon.TintColor = textColor;
@@ -957,6 +975,11 @@ namespace XF.Material.Forms.UI
         {
             trailingIcon.TintColor = this.TextColor;
             persistentUnderline.Color = this.UnderlineColor;
+
+            placeholder.FontSize = this.FontSize;
+            entry.FontSize = this.FontSize;
+            entry.HeightRequest = entry.FontSize * 1.25;
+
             tapGesture.Command = new Command(() =>
             {
                 if (!entry.IsFocused)
@@ -987,6 +1010,7 @@ namespace XF.Material.Forms.UI
             propertyChangeActions = new Dictionary<string, Action>
             {
                 { nameof(this.Text), () => this.OnTextChanged(this.Text) },
+                { nameof(this.FontSize), () => this.OnFontSizeChanged(this.FontSize) },
                 { nameof(this.TextColor), () => this.OnTextColorChanged(this.TextColor) },
                 { nameof(this.TextFontFamily), () => this.OnTextFontFamilyChanged(this.TextFontFamily) },
                 { nameof(this.TintColor), () => this.OnTintColorChanged(this.TintColor) },


### PR DESCRIPTION
This pull request adds the ability to set a FontSize for the Material Entry.

It adds the property "FontSizeProperty" to "MaterialTextField" with a default of 16.

On the Control i replaced every instance of hardcoded 16 with `this.FontSize` and every instance of 12 with `this.FontSize*0.75` to preserve the ratio in the animations.

The FontSize controls the Label (placeholder) size and the Entry (entry) size.

Also updated the demo example adding a FontSize of 20 to the third MaterialTextField