### PR TITLE
Added an animation to fade the gray background in MaterialRippleGestureRecognizer for iOS after 1.5 seconds

### DIFF
--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/BaseMaterialModalPage.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/BaseMaterialModalPage.cs
@@ -36,6 +36,15 @@ namespace XF.Material.Forms.UI.Dialogs
         public virtual bool Dismissable => true;
 
         /// <summary>
+        /// Sets the message text.
+        /// </summary>
+        /// <param name="text">Text.</param>
+        public virtual void SetMessageText(string text)
+        {
+
+        }
+
+        /// <summary>
         /// Dismisses this modal dialog asynchronously.
         /// </summary>
         public async Task DismissAsync()

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/BaseMaterialModalPage.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/BaseMaterialModalPage.cs
@@ -35,14 +35,12 @@ namespace XF.Material.Forms.UI.Dialogs
 
         public virtual bool Dismissable => true;
 
-        /// <summary>
-        /// Sets the message text.
-        /// </summary>
-        /// <param name="text">Text.</param>
-        public virtual void SetMessageText(string text)
+        public virtual string MessageText
         {
-
+            get { return ""; }
+            set { }
         }
+
 
         /// <summary>
         /// Dismisses this modal dialog asynchronously.

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/IMaterialModalPage.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/IMaterialModalPage.cs
@@ -6,10 +6,9 @@ namespace XF.Material.Forms.UI.Dialogs
     public interface IMaterialModalPage : IDisposable
     {
         /// <summary>
-        /// Sets the message text.
+        /// Gets or sets the message text.
         /// </summary>
-        /// <param name="text">Text.</param>
-        void SetMessageText(string text);
+        string MessageText { get; set; }
 
         /// <summary>
         /// Dismisses this modal dialog asynchronously.

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/IMaterialModalPage.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/IMaterialModalPage.cs
@@ -6,6 +6,12 @@ namespace XF.Material.Forms.UI.Dialogs
     public interface IMaterialModalPage : IDisposable
     {
         /// <summary>
+        /// Sets the message text.
+        /// </summary>
+        /// <param name="text">Text.</param>
+        void SetMessageText(string text);
+
+        /// <summary>
         /// Dismisses this modal dialog asynchronously.
         /// </summary>
         Task DismissAsync();

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialLoadingDialog.xaml.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialLoadingDialog.xaml.cs
@@ -47,5 +47,11 @@ namespace XF.Material.Forms.UI.Dialogs
                 LoadingImage.TintColor = preferredConfig.TintColor;
             }
         }
+
+
+        public override void SetMessageText(string text)
+        {
+            Message.Text = text;
+        }
     }
 }

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialLoadingDialog.xaml.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialLoadingDialog.xaml.cs
@@ -16,6 +16,13 @@ namespace XF.Material.Forms.UI.Dialogs
 
         public override bool Dismissable => false;
 
+        public override string MessageText
+        {
+            get { return this.Message.Text; }
+            set { this.Message.Text = value; }
+        }
+
+
         internal static MaterialLoadingDialogConfiguration GlobalConfiguration { get; set; }
 
         internal static async Task<IMaterialModalPage> Loading(string message, MaterialLoadingDialogConfiguration configuration = null)
@@ -49,9 +56,5 @@ namespace XF.Material.Forms.UI.Dialogs
         }
 
 
-        public override void SetMessageText(string text)
-        {
-            Message.Text = text;
-        }
     }
 }

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialSnackbar.xaml.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialSnackbar.xaml.cs
@@ -36,6 +36,12 @@ namespace XF.Material.Forms.UI.Dialogs
 
         public TaskCompletionSource<bool> InputTaskCompletionSource { get; set; }
 
+        public override string MessageText
+        {
+            get { return this.Message.Text; }
+            set { this.Message.Text = value; }
+        }
+
         public override bool Dismissable => false;
 
         internal static MaterialSnackbarConfiguration GlobalConfiguration { get; set; }
@@ -95,11 +101,6 @@ namespace XF.Material.Forms.UI.Dialogs
                 ActionButton.AllCaps = preferredConfig.ButtonAllCaps;
                 Container.Margin = new Thickness(8, 0, 8, preferredConfig.BottomOffset);
             }
-        }
-
-        public override void SetMessageText(string text)
-        {
-            Message.Text = text;
         }
 
     }

--- a/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialSnackbar.xaml.cs
+++ b/XF.Material/XF.Material.Forms/Ui/Dialogs/MaterialSnackbar.xaml.cs
@@ -96,5 +96,11 @@ namespace XF.Material.Forms.UI.Dialogs
                 Container.Margin = new Thickness(8, 0, 8, preferredConfig.BottomOffset);
             }
         }
+
+        public override void SetMessageText(string text)
+        {
+            Message.Text = text;
+        }
+
     }
 }


### PR DESCRIPTION
Apparently the TapGestureRecognizer for iOS times out if the user holds the tap for an estimated more than 1.5 seconds. When that happens, none of the TouchesEnded, TouchesMoved, TouchesCancelled events are triggered for us to fade the gray background out. So this animation chain will ensure that the background will be faded out.
