### PR TITLE
Added the possibility to change the FontSize on a MaterialChip control

### DIFF
--- a/Samples/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
+++ b/Samples/MaterialMvvmSample.Android/MaterialMvvmSample.Android.csproj
@@ -29,10 +29,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
-    <AotAssemblies>false</AotAssemblies>
-    <EnableLLVM>false</EnableLLVM>
-    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
-    <BundleAssemblies>false</BundleAssemblies>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidDexTool>d8</AndroidDexTool>
     <AndroidLinkTool>r8</AndroidLinkTool>

--- a/Samples/MaterialMvvmSample.Core/AppContainer.cs
+++ b/Samples/MaterialMvvmSample.Core/AppContainer.cs
@@ -32,6 +32,7 @@ namespace MaterialMvvmSample.Core
             containerBuilder.RegisterType<JobDialogService>().As<IJobDialogService>().InstancePerDependency();
 
             containerBuilder.RegisterType<MainView>().Named<Page>(ViewNames.MainView).As<MainView>().InstancePerDependency();
+            containerBuilder.RegisterType<ChipFontSizeView>().Named<Page>(ViewNames.ChipFontSizeView).As<ChipFontSizeView>().InstancePerDependency();
             containerBuilder.RegisterType<SecondView>().Named<Page>(ViewNames.SecondView).As<SecondView>().InstancePerDependency();
 
             containerBuilder.RegisterType<MainViewModel>().InstancePerDependency();

--- a/Samples/MaterialMvvmSample/App.xaml.cs
+++ b/Samples/MaterialMvvmSample/App.xaml.cs
@@ -14,7 +14,7 @@ namespace MaterialMvvmSample
 
             XF.Material.Forms.Material.Init(this, "Material.Style");
 
-            navigationService.SetRootView(ViewNames.MainView);
+            navigationService.SetRootView(ViewNames.ChipFontSizeView);
         }
 
         protected override void OnStart()

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="ChipFontSizeView.xaml" />
   </ItemGroup>
   
 </Project>

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Update="**\*.xaml.cs" DependentUpon="ChipFontSizeView.xaml" />
+    <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
   
 </Project>

--- a/Samples/MaterialMvvmSample/Views/ChipFontSizeView.xaml
+++ b/Samples/MaterialMvvmSample/Views/ChipFontSizeView.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:BaseMainView x:Class="MaterialMvvmSample.Views.ChipFontSizeView"
+                    xmlns="http://xamarin.com/schemas/2014/forms"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                    xmlns:local="clr-namespace:MaterialMvvmSample.Views"
+                    xmlns:matd="clr-namespace:XF.Material.Forms.UI.Dialogs;assembly=XF.Material"
+                    xmlns:matdc="clr-namespace:XF.Material.Forms.UI.Dialogs.Configurations;assembly=XF.Material"
+                    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
+                    x:Name="Root"
+                    Title="Material MVVM"
+                    material:MaterialNavigationPage.AppBarColor="#2c3e50"
+                    material:MaterialNavigationPage.AppBarTitleTextAlignment="Start"
+                    material:MaterialNavigationPage.AppBarTitleTextFontFamily="{StaticResource FontFamily.RobotoMedium}"
+                    material:MaterialNavigationPage.AppBarTitleTextFontSize="14"
+                    material:MaterialNavigationPage.StatusBarColor="#1B3147">
+    <ContentPage.Content>
+
+        <StackLayout Padding="32,16"
+                     Orientation="Vertical"
+                     HorizontalOptions="FillAndExpand"
+                     VerticalOptions="CenterAndExpand">
+
+            <material:MaterialLabel Text="Chip Font Size" />
+
+            <material:MaterialChip x:Name="TheChip"
+                                   Text="MyChip"
+                                   BackgroundColor="Blue"
+                                   TextColor="White" />
+
+            <Button Text="IncreaseChipFontSize"
+                    Clicked="IncreaseChipFontSize_Clicked" />
+
+            <Button Text="DecreaseChipFontSize"
+                    Clicked="DecreaseChipFontSize_Clicked" />
+        </StackLayout>
+
+    </ContentPage.Content>
+</local:BaseMainView>

--- a/Samples/MaterialMvvmSample/Views/ChipFontSizeView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/ChipFontSizeView.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace MaterialMvvmSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ChipFontSizeView : BaseMainView
+    {
+        public ChipFontSizeView()
+        {
+            InitializeComponent();
+        }
+
+        public void IncreaseChipFontSize_Clicked(object sender, EventArgs e)
+        {
+            this.TheChip.FontSize = this.TheChip.FontSize + 1;
+        }
+
+        public void DecreaseChipFontSize_Clicked(object sender, EventArgs e)
+        {
+            this.TheChip.FontSize = this.TheChip.FontSize - 1;
+        }
+    }
+}

--- a/Samples/MaterialMvvmSample/Views/ViewNames.cs
+++ b/Samples/MaterialMvvmSample/Views/ViewNames.cs
@@ -4,6 +4,8 @@
     {
         public const string MainView = nameof(Views.MainView);
 
+        public const string ChipFontSizeView = nameof(Views.ChipFontSizeView);
+
         public const string SecondView = nameof(Views.SecondView);
     }
 }

--- a/XF.Material/UI/MaterialChip.xaml.cs
+++ b/XF.Material/UI/MaterialChip.xaml.cs
@@ -18,6 +18,7 @@ namespace XF.Material.Forms.UI
         public static readonly BindableProperty ImageTintColorProperty = BindableProperty.Create(nameof(ImageTintColor), typeof(Color), typeof(MaterialChip), default(Color));
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(MaterialChip), Color.FromHex("#DE000000"));
         public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialChip), string.Empty);
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(nameof(FontSize), typeof(double), typeof(MaterialChip), 14.0);
 
         private bool _canExecute;
 
@@ -82,6 +83,12 @@ namespace XF.Material.Forms.UI
             set => SetValue(TextColorProperty, value);
         }
 
+        public double FontSize
+        {
+            get => (double)GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
+        }
+
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
             if (propertyName == nameof(BackgroundColor))
@@ -96,6 +103,9 @@ namespace XF.Material.Forms.UI
                 {
                     case nameof(Text):
                         ChipLabel.Text = Text;
+                        break;
+                    case nameof(FontSize):
+                        ChipLabel.FontSize = FontSize;
                         break;
                     case nameof(ActionImageTintColor):
                         ChipActionImage.TintColor = ActionImageTintColor;


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Small modification of the MaterialChip control, to give users the possibility of modifying its FontSize.

### :arrow_heading_down: What is the current behavior?
You can't change the FontSize on a MaterialChip view

### :new: What is the new behavior (if this is a feature change)?
Possibility to databind the value of a MaterialChip.FontSize property

### :boom: Does this PR introduce a breaking change?
Nope

### :bug: Recommendations for testing
A new page is available in the Sample project MaterialChipFontSizeView, for testing purpuses

### :memo: Links to relevant issues/docs
https://github.com/BaseflowIT/XF-Material-Library/issues/154

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
