### PR TITLE
Fixed nuget badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 <img src="images/xf.material_logo.png" width="112" />
 
-# XF.Material Library [![NuGet](https://img.shields.io/badge/version-1.4.1.3-orange.svg?style=flat)](https://github.com/contrix09/XF-Material-Library/blob/master/RELEASE_NOTES.md) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
+# XF.Material Library
+
+[![NuGet](https://img.shields.io/nuget/v/XF.Material?color=orange)](https://www.nuget.org/packages/XF.Material/) [![Build status](https://dev.azure.com/compiledevops/XF.Material/_apis/build/status/XF.Material-CI%20NuGet)](https://dev.azure.com/compiledevops/XF.Material/_build/latest?definitionId=20)
 
 A Xamarin.Forms library for Xamarin.Android and Xamarin.iOS to implement [Google's Material Design](https://material.io/design).
 


### PR DESCRIPTION
The NuGet badge showed a hardcoded version and redirected to a release note markdown file. I fixed it so it shows the latest version and redirects to NuGet.