### PR TITLE
Trying to fix iOS assets management with the library

### DIFF
--- a/XF.Material/Info.plist
+++ b/XF.Material/Info.plist
@@ -23,7 +23,7 @@
 	<key>MinimumOSVersion</key>
 	<string>6.0</string>
 	<key>CFBundleDisplayName</key>
-	<string>MaterialMvvmSample</string>
+	<string>XF.Material</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>CFBundleName</key>

--- a/XF.Material/Info.plist
+++ b/XF.Material/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>MinimumOSVersion</key>
+	<string>6.0</string>
+	<key>CFBundleDisplayName</key>
+	<string>MaterialMvvmSample</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleName</key>
+	<string>XF.Material</string>
+</dict>
+</plist>

--- a/XF.Material/readme.txt
+++ b/XF.Material/readme.txt
@@ -11,3 +11,10 @@ Star on Github if this project helps you: https://github.com/BaseflowIT/XF-Mater
 Commercial support is available. Integration with your app or services, samples, feature request, etc. Email: hello@baseflow.com
 Powered by: https://baseflow.com
 ---------------------------------
+
+---------------------------------
+XF.Material Info.plist file
+---------------------------------
+Because of a bug in Assets management for Xamarin.iOS projects, it is required to include a very basic Info.plist file
+into the XF.Material project, to avoid XF.Material library's assets to be overriden by the final app's assets.
+DO NOT MODIFY the Info.plist file


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Trying to make the iOS assets (checkbox images, material loader animation ...) display properly when the nuget package is used in a real project

### :arrow_heading_down: What is the current behavior?
iOS assets don't show up in a real app

### :new: What is the new behavior (if this is a feature change)?
iOS assets **should** be working fine

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
This has only been tested locally, on a mac (created a local nuget package, referenced in a test project outside of the main solution).
It should be tested on windows if possible, before pushing a "pre-release" nuget package to make it possible to test it in real conditions, with the nuget package coming from the nuget repository

### :memo: Links to relevant issues/docs
https://github.com/BaseflowIT/XF-Material-Library/issues/195
Ref to this bug: https://xamarin.github.io/bugzilla-archives/34/34762/bug.html

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
