### PR TITLE
Reproducing of  #159 MaterialMenuButton does not show three dots

### DIFF
--- a/Samples/MaterialMvvmSample.Core/AppContainer.cs
+++ b/Samples/MaterialMvvmSample.Core/AppContainer.cs
@@ -41,9 +41,8 @@ namespace MaterialMvvmSample.Core
             containerBuilder.RegisterType<CheckboxesView>().Named<Page>(ViewNames.CheckboxesView).As<CheckboxesView>().InstancePerDependency();
             containerBuilder.RegisterType<MaterialTextFieldView>().Named<Page>(ViewNames.MaterialTextFieldView).As<MaterialTextFieldView>().InstancePerDependency();
             containerBuilder.RegisterType<MaterialCircularView>().Named<Page>(ViewNames.MaterialCircularView).As<MaterialCircularView>().InstancePerDependency();
-
-
-
+            containerBuilder.RegisterType<MaterialMenuButtonView>().Named<Page>(ViewNames.MaterialMenuButtonView).As<MaterialMenuButtonView>().InstancePerDependency();
+            
             containerBuilder.RegisterType<MainViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<SecondViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<LandingViewModel>().InstancePerDependency();

--- a/Samples/MaterialMvvmSample.Core/AppContainer.cs
+++ b/Samples/MaterialMvvmSample.Core/AppContainer.cs
@@ -46,6 +46,14 @@ namespace MaterialMvvmSample.Core
             containerBuilder.RegisterType<MainViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<SecondViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<LandingViewModel>().InstancePerDependency();
+
+
+
+
+
+
+            containerBuilder.RegisterType<MaterialMenuButtonViewModel>().InstancePerDependency();
+
         }
     }
 }

--- a/Samples/MaterialMvvmSample.Core/AppContainer.cs
+++ b/Samples/MaterialMvvmSample.Core/AppContainer.cs
@@ -38,21 +38,24 @@ namespace MaterialMvvmSample.Core
 
             containerBuilder.RegisterType<LandingView>().Named<Page>(ViewNames.LandingView).As<LandingView>().InstancePerDependency();
             containerBuilder.RegisterType<MaterialDialogsView>().Named<Page>(ViewNames.MaterialDialogsView).As<MaterialDialogsView>().InstancePerDependency();
-            containerBuilder.RegisterType<CheckboxesView>().Named<Page>(ViewNames.CheckboxesView).As<CheckboxesView>().InstancePerDependency();
             containerBuilder.RegisterType<MaterialTextFieldView>().Named<Page>(ViewNames.MaterialTextFieldView).As<MaterialTextFieldView>().InstancePerDependency();
             containerBuilder.RegisterType<MaterialCircularView>().Named<Page>(ViewNames.MaterialCircularView).As<MaterialCircularView>().InstancePerDependency();
-            containerBuilder.RegisterType<MaterialMenuButtonView>().Named<Page>(ViewNames.MaterialMenuButtonView).As<MaterialMenuButtonView>().InstancePerDependency();
-            
+            containerBuilder.RegisterType<CheckboxesView>().Named<Page>(ViewNames.CheckboxesView).As<CheckboxesView>().InstancePerDependency();
+
+
+
+
+
+
+
             containerBuilder.RegisterType<MainViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<SecondViewModel>().InstancePerDependency();
             containerBuilder.RegisterType<LandingViewModel>().InstancePerDependency();
-
-
-
-
-
-
-            containerBuilder.RegisterType<MaterialMenuButtonViewModel>().InstancePerDependency();
+            containerBuilder.RegisterType<CheckboxesViewModel>().InstancePerDependency();
+            containerBuilder.RegisterType<ChipFontSizeViewModel>().InstancePerDependency();
+            containerBuilder.RegisterType<MaterialCircularViewModel>().InstancePerDependency();
+            containerBuilder.RegisterType<MaterialDialogsViewModel>().InstancePerDependency();
+            containerBuilder.RegisterType<MaterialTextFieldViewModel>().InstancePerDependency();
 
         }
     }

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-     <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
+     <Compile Update="**\*.xaml.cs" DependentUpon="MaterialMenuButtonView.xaml" />
   </ItemGroup>
   
 </Project>

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-     <Compile Update="**\*.xaml.cs" DependentUpon="MaterialMenuButtonView.xaml" />
+     <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
   </ItemGroup>
   
 </Project>

--- a/Samples/MaterialMvvmSample/ViewModels/LandingViewModel.cs
+++ b/Samples/MaterialMvvmSample/ViewModels/LandingViewModel.cs
@@ -2,6 +2,7 @@
 using System.Windows.Input;
 using MaterialMvvmSample.Views;
 using Xamarin.Forms;
+using XF.Material.Forms.Models;
 
 namespace MaterialMvvmSample.ViewModels
 {
@@ -17,6 +18,9 @@ namespace MaterialMvvmSample.ViewModels
 
         public ICommand GoToMaterialTextFieldSampleCommand => this.GoToCommand(ViewNames.MaterialTextFieldView);
 
+        public ICommand GoToMaterialMenuButtonViewCommand => this.GoToCommand(ViewNames.MaterialMenuButtonView);
+
         private ICommand GoToCommand(string name) => new Command(() => this.Navigation.PushAsync(name));
+
     }
 }

--- a/Samples/MaterialMvvmSample/ViewModels/MainViewModel.cs
+++ b/Samples/MaterialMvvmSample/ViewModels/MainViewModel.cs
@@ -44,18 +44,6 @@ namespace MaterialMvvmSample.ViewModels
 
         public Color PrimaryColor => Color.Red;
 
-        public MaterialMenuItem[] Actions => new MaterialMenuItem[]
-        {
-            new MaterialMenuItem
-            {
-                Text = "Edit"
-            },
-            new MaterialMenuItem
-            {
-                Text = "Delete"
-            }
-        };
-
         private string _selectedChoice;
         public string SelectedChoice
         {

--- a/Samples/MaterialMvvmSample/ViewModels/MaterialMenuButtonViewModel.cs
+++ b/Samples/MaterialMvvmSample/ViewModels/MaterialMenuButtonViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using XF.Material.Forms.Models;
+
+namespace MaterialMvvmSample.ViewModels
+{
+    public class MaterialMenuButtonViewModel : BaseViewModel
+    {
+        public MaterialMenuItem[] Actions => new MaterialMenuItem[]
+        {
+            new MaterialMenuItem
+            {
+                Text = "Edit"
+            },
+            new MaterialMenuItem
+            {
+                Text = "Delete"
+            }
+        };
+    }
+}

--- a/Samples/MaterialMvvmSample/Views/LandingView.xaml
+++ b/Samples/MaterialMvvmSample/Views/LandingView.xaml
@@ -27,7 +27,11 @@
                                      Command="{Binding GoToMaterialCircularViewCommand}"
                                      Margin="10" />
 
-            <!-- New sample shortcuts should be added here (Button + Associated command in the LandingViewModel) -->
+            <material:MaterialButton Text="Go To MaterialMenuButton sample"
+                                     Command="{Binding GoToMaterialMenuButtonViewCommand}"
+                                     Margin="10" />
+
+          <!-- New sample shortcuts should be added here (Button + Associated command in the LandingViewModel) -->
         </StackLayout>
     </ContentPage.Content>
 </local:BaseLandingView>

--- a/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<views:BaseMainView
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:views="clr-namespace:MaterialMvvmSample.Views"
+    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
+    x:Class="MaterialMvvmSample.Views.MaterialMenuButtonView"
+    >
+
+    <ContentPage.Content>
+        <StackLayout>
+            <material:MaterialMenuButton ButtonType="Outlined" CornerRadius="24" Choices="{Binding Actions}" Margin="10" />
+        </StackLayout>
+
+    </ContentPage.Content>
+</views:BaseMainView>

--- a/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
@@ -9,7 +9,7 @@
 
     <ContentPage.Content>
         <StackLayout>
-            <material:MaterialMenuButton ButtonType="Outlined" CornerRadius="24" Choices="{Binding Actions}" Margin="10" />
+            <material:MaterialMenuButton ButtonType="Outlined" CornerRadius="24" Choices="{Binding Actions}" Command="{Binding MenuCommand}" Margin="10" />
         </StackLayout>
 
     </ContentPage.Content>

--- a/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<views:BaseMainView
+<ContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:MaterialMvvmSample.Views"
@@ -13,4 +13,4 @@
         </StackLayout>
 
     </ContentPage.Content>
-</views:BaseMainView>
+</ContentPage>

--- a/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using XF.Material.Forms.Models;
+
+namespace MaterialMvvmSample.Views
+{
+    public partial class MaterialMenuButtonView : BaseMainView
+    {
+        public MaterialMenuButtonView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/MaterialMenuButtonView.xaml.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using MaterialMvvmSample.ViewModels;
 using Xamarin.Forms;
 using XF.Material.Forms.Models;
 
 namespace MaterialMvvmSample.Views
 {
-    public partial class MaterialMenuButtonView : BaseMainView
+    public partial class MaterialMenuButtonView : ContentPage
     {
         public MaterialMenuButtonView()
         {
             InitializeComponent();
+            BindingContext = new MaterialMenuButtonViewModel();
         }
     }
 }

--- a/Samples/MaterialMvvmSample/Views/ViewNames.cs
+++ b/Samples/MaterialMvvmSample/Views/ViewNames.cs
@@ -17,5 +17,7 @@
         public const string MaterialTextFieldView = nameof(Views.MaterialTextFieldView);
 
         public const string MaterialCircularView = nameof(Views.MaterialCircularView);
+
+        public const string MaterialMenuButtonView = nameof(Views.MaterialMenuButtonView);
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Reproduction of #159 MaterialMenuButton does not show three dots

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
Reproduction of #159 MaterialMenuButton does not show three dots. But I made an outline button instead of a text. Otherwise the button was there but not showing

### :boom: Does this PR introduce a breaking change?
NO

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
