### PR TITLE
Reproducing #151 LoadingDialog works just like example

### DIFF
--- a/Samples/MaterialMvvmSample/ViewModels/MaterialCircularViewModel.cs
+++ b/Samples/MaterialMvvmSample/ViewModels/MaterialCircularViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+
 namespace MaterialMvvmSample.ViewModels
 {
     public class MaterialCircularViewModel : BaseViewModel

--- a/Samples/MaterialMvvmSample/Views/MaterialCircularView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/MaterialCircularView.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using MaterialMvvmSample.ViewModels;
 using Xamarin.Forms;
+using XF.Material.Forms.UI.Dialogs;
 
 namespace MaterialMvvmSample.Views
 {
@@ -11,6 +13,14 @@ namespace MaterialMvvmSample.Views
         {
             InitializeComponent();
             BindingContext = new MaterialCircularViewModel();
+            RunLoadingDialog();
+        }
+
+        public async Task RunLoadingDialog()
+        {
+            var loadingDialog = await MaterialDialog.Instance.LoadingDialogAsync(message: "Something is running");
+            await Task.Delay(5000); // Represents a task that is running.
+            await loadingDialog.DismissAsync();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
#151   Reproduction LoadingDialog cannot be dismissed. With the current code it works fine. The current code is from Read.Me

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?
LoadingDialog added 

### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
