### PR TITLE
Enhancement for MaterialNavigationPage;

### DIFF
--- a/XF.Material/Platforms/Android/Renderers/MaterialNavigationPageRenderer.cs
+++ b/XF.Material/Platforms/Android/Renderers/MaterialNavigationPageRenderer.cs
@@ -36,6 +36,15 @@ namespace XF.Material.Droid.Renderers
             _toolbar = ViewGroup.GetChildAt(0) as Toolbar;
         }
 
+        protected override Task<bool> OnPopToRootAsync(Page page, bool animated)
+        {
+            _navigationPage.InternalPopToRoot(page);
+
+            ChangeHasShadow(page);
+
+            return base.OnPopToRootAsync(page, animated);
+        }
+
         protected override Task<bool> OnPopViewAsync(Page page, bool animated)
         {
             var navStack = _navigationPage.Navigation.NavigationStack.ToList();

--- a/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
@@ -50,6 +50,15 @@ namespace XF.Material.iOS.Renderers
             }
         }
 
+        protected override Task<bool> OnPopToRoot(Page page, bool animated)
+        {
+            _navigationPage.InternalPopToRoot(page);
+
+            ChangeHasShadow(page);
+
+            return base.OnPopToRoot(page, animated);
+        }
+
         protected override Task<bool> OnPopViewAsync(Page page, bool animated)
         {
             var pop = base.OnPopViewAsync(page, animated);

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -226,16 +226,16 @@ namespace XF.Material.Forms.UI
 
             if (e?.PropertyName == nameof(Title) && page?.GetValue(TitleViewProperty) is TitleLabel label)
                 label.Text = page.Title;
-            else if (e?.PropertyName == "AppBarColor" && page != null)
-                UpdatePageProperties(page);
-            else if (e?.PropertyName == "AppBarTitleTextFontFamily" && page != null)
-                UpdatePageProperties(page);
-            else if (e?.PropertyName == "AppBarTitleTextFontSize" && page != null)
-                UpdatePageProperties(page);
             else if (e?.PropertyName == "StatusBarColor" && page != null)
-                UpdatePageProperties(page);
+                ChangeStatusBarColor(page);
+            else if (e?.PropertyName == "AppBarColor" && page != null)
+                ChangeBarBackgroundColor(page);
+            else if (e?.PropertyName == "AppBarTitleTextFontFamily" && page != null)
+                ChangeFont(page);
+            else if (e?.PropertyName == "AppBarTitleTextFontSize" && page != null)
+                ChangeFont(page);
             else if (e?.PropertyName == "AppBarTitleTextAlignment" && page != null)
-                UpdatePageProperties(page);
+                ChangeFont(page);
         }
 
         protected override void OnAppearing()
@@ -251,7 +251,7 @@ namespace XF.Material.Forms.UI
         /// <param name="rootPage">The root page.</param>
         protected virtual void OnPopToRoot(Page rootPage)
         {
-            UpdatePageProperties(rootPage);
+            UpdatePage(rootPage);
 
             rootPage.SetValue(BackButtonTitleProperty, string.Empty);
         }
@@ -263,7 +263,7 @@ namespace XF.Material.Forms.UI
         /// <param name="poppedPage">The page that will be popped.</param>
         protected virtual void OnPagePop(Page previousPage, Page poppedPage)
         {
-            UpdatePageProperties(previousPage);
+            UpdatePage(previousPage);
 
             previousPage.SetValue(BackButtonTitleProperty, string.Empty);
         }
@@ -274,12 +274,12 @@ namespace XF.Material.Forms.UI
         /// <param name="page">The page that is being pushed.</param>
         protected virtual void OnPagePush(Page page)
         {
-            UpdatePageProperties(page);
+            UpdatePage(page);
 
             page.SetValue(BackButtonTitleProperty, string.Empty);
         }
 
-        private void UpdatePageProperties(Page page)
+        private void UpdatePage(Page page)
         {
             if (page.BackgroundColor.IsDefault)
             {


### PR DESCRIPTION
Add InternalPopToRoot and update properties;

(OnAppearing) Remove _firstLoad and change StatusBarColor for the CurrentPage being displayed, not the RootPage.This fixes a bug when using a tabbed page where each tab has a different value for the StatusBarColor property, and by changing the selected tab does not change the color of statusbar;

Update Properties when Page_PropertyChanged is raised -- which makes possible to see changes with HotReload.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fixes, enhancements...

### :arrow_heading_down: What is the current behavior?
For now when you call navigationpage's PopToRoot method the StatusBar and Toolbar values are not updated. It is also not possible to see property value changes in runtime using HotReload.

### :new: What is the new behavior (if this is a feature change)?
*See changes in HotReload
*Fix a bug when PopToRoot not updating Toolbar/StatusBar
*Fix a bug when using a tabbed page where each tab has a different value for the StatusBarColor property, and by changing the selected tab does not change the color of statusbar based on the current page;

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
