### PR TITLE
[MaterialNavigationPage][iOS] Better behavior when a page is being popped

### DIFF
--- a/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using CoreGraphics;
+using ObjCRuntime;
 using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
@@ -47,6 +48,7 @@ namespace XF.Material.iOS.Renderers
             if (e?.NewElement != null)
             {
                 _navigationPage = Element as MaterialNavigationPage;
+                Delegate = new NavigationControllerDelegate(this, _navigationPage);
             }
         }
 
@@ -88,6 +90,34 @@ namespace XF.Material.iOS.Renderers
             var hasShadow = (bool)page.GetValue(MaterialNavigationPage.HasShadowProperty);
 
             ChangeHasShadow(hasShadow);
+        }
+
+        class NavigationControllerDelegate : UINavigationControllerDelegate
+        {
+            private UINavigationController _navigationController;
+            private MaterialNavigationPage _navigationPage;
+
+            public NavigationControllerDelegate(UINavigationController uINavigationController, MaterialNavigationPage navigationPage)
+            {
+                _navigationController = uINavigationController;
+                _navigationPage = navigationPage;
+            }
+
+            public override void WillShowViewController(UINavigationController navigationController, [Transient] UIViewController viewController, bool animated)
+            {
+                var coordinator = _navigationController?.TopViewController?.GetTransitionCoordinator();
+
+                if (coordinator == null)
+                    return;
+
+                coordinator.NotifyWhenInteractionChanges((context) =>
+                {
+                    if (context.IsCancelled)
+                    {
+                        _navigationPage.ForceUpdateCurrentPage();
+                    }
+                });
+            }
         }
     }
 }

--- a/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialNavigationPageRenderer.cs
@@ -50,30 +50,28 @@ namespace XF.Material.iOS.Renderers
             }
         }
 
-        protected override Task<bool> OnPopToRoot(Page page, bool animated)
+        public override UIViewController[] PopToRootViewController(bool animated)
         {
-            _navigationPage.InternalPopToRoot(page);
-
-            ChangeHasShadow(page);
-
-            return base.OnPopToRoot(page, animated);
+            _navigationPage.InternalPopToRoot(_navigationPage.RootPage);
+            ChangeHasShadow(_navigationPage.RootPage);
+            return base.PopToRootViewController(animated);
         }
 
-        protected override Task<bool> OnPopViewAsync(Page page, bool animated)
+        public override UIViewController PopViewController(bool animated)
         {
-            var pop = base.OnPopViewAsync(page, animated);
             var navStack = _navigationPage.Navigation.NavigationStack.ToList();
 
             if (navStack.Count - 1 - navStack.IndexOf(_navigationPage.CurrentPage) < 0)
             {
-                return pop;
+                return base.PopViewController(animated);
             }
 
+            var currentPage = _navigationPage.CurrentPage;
             var previousPage = navStack[navStack.IndexOf(_navigationPage.CurrentPage) - 1];
-            _navigationPage.InternalPagePop(previousPage, page);
+            _navigationPage.InternalPagePop(previousPage, currentPage);
             ChangeHasShadow(previousPage);
 
-            return pop;
+            return base.PopViewController(animated);
         }
 
         protected override Task<bool> OnPushAsync(Page page, bool animated)

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -233,17 +233,20 @@ namespace XF.Material.Forms.UI
         {
             var page = sender as Page;
 
-            if (e?.PropertyName == nameof(Title) && page?.GetValue(TitleViewProperty) is TitleLabel label)
+            if (page == null)
+                return;
+
+            if (e.PropertyName == nameof(Title) && page.GetValue(TitleViewProperty) is TitleLabel label)
                 label.Text = page.Title;
-            else if (e?.PropertyName == "StatusBarColor" && page != null)
+            else if (e.PropertyName == StatusBarColorProperty.PropertyName)
                 ChangeStatusBarColor(page);
-            else if (e?.PropertyName == "AppBarColor" && page != null)
+            else if (e.PropertyName == AppBarColorProperty.PropertyName)
                 ChangeBarBackgroundColor(page);
-            else if (e?.PropertyName == "AppBarTitleTextFontFamily" && page != null)
+            else if (e.PropertyName == AppBarTitleTextFontFamilyProperty.PropertyName)
                 ChangeFont(page);
-            else if (e?.PropertyName == "AppBarTitleTextFontSize" && page != null)
+            else if (e.PropertyName == AppBarTitleTextFontSizeProperty.PropertyName)
                 ChangeFont(page);
-            else if (e?.PropertyName == "AppBarTitleTextAlignment" && page != null)
+            else if (e.PropertyName == AppBarTitleTextAlignmentProperty.PropertyName)
                 ChangeFont(page);
         }
 

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -200,6 +200,15 @@ namespace XF.Material.Forms.UI
             OnPagePush(page);
         }
 
+        /// <summary>
+        /// For internal use only.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void ForceUpdateCurrentPage()
+        {
+            UpdatePage(CurrentPage);
+        }
+
         protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
         {
             base.OnPropertyChanging(propertyName);


### PR DESCRIPTION
I was wondering why iOS takes so long to call the OnPopViewAsync method, causing it to take time to update the color of The AppBar and giving the user a terrible feeling.

So I replace the 'OnPopViewAsync' method with 'PopViewController' because it's called earlier.

But there was still a problem when using a TabbedPage on iOS:

By reselecting a UITabBarItem (when it is a NavigationPage), the OnPopToRoot() method was never called, instead Xamarin.iOS called the OnPopViewAsync method for each page in NavigationStack, changing the color until it reaches RootPage.

To solve this other problem the solution was rather than overwriting the 'OnPopToRoot' method overwriting 'PopToRootViewController'.

I attached a quick video to demonstrate the old and new behavior for a better understanding.

Demonstration: https://drive.google.com/open?id=1bYuE7EV_wgOeY4qyjgTFx_thGT45r9v3

EDIT: 

I also added a class that inherits from 'UINavigationControllerDelegate' and assigns to the NavigationControler 'Delegate' property to detect when the user cancels an 'InteractivePopGestureRecognizer': https://stackoverflow.com/a/21155863