### PR TITLE
#236 space under MaterialTextField gone

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml
+++ b/XF.Material/UI/MaterialTextField.xaml
@@ -19,7 +19,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition x:Name="_autoSizingRow"
                                Height="56" />
-                <RowDefinition Height="20" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
 #236 space under MaterialTextField gone

### :arrow_heading_down: What is the current behavior?
To much space under materialTextField

### :new: What is the new behavior (if this is a feature change)?
No more space under MaterialTextField

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
