### PR TITLE
[Bug] [TitleView] InvalidCastException fix

### DIFF
--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -343,22 +343,20 @@ namespace XF.Material.Forms.UI
 
         private void ChangeFont(Page page)
         {
-            var titleView = page.GetValue(TitleViewProperty);
-
-            if (titleView != null && titleView.GetType() != typeof(TitleLabel))
-            {
-                return;
-            }
+            var currentTitleView = page.GetValue(TitleViewProperty);
 
             var textAlignment = (TextAlignment)page.GetValue(AppBarTitleTextAlignmentProperty);
             var fontFamily = (string)page.GetValue(AppBarTitleTextFontFamilyProperty);
             var fontSize = (double)page.GetValue(AppBarTitleTextFontSizeProperty);
 
-            if (titleView is TitleLabel currentTitleView)
+            if (currentTitleView != null)
             {
-                currentTitleView.HorizontalTextAlignment = textAlignment;
-                currentTitleView.FontFamily = fontFamily;
-                currentTitleView.FontSize = fontSize;
+                if (currentTitleView is TitleLabel titleLabelView)
+                {
+                    titleLabelView.HorizontalTextAlignment = textAlignment;
+                    titleLabelView.FontFamily = fontFamily;
+                    titleLabelView.FontSize = fontSize;
+                }
                 return;
             }
 

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -343,16 +343,16 @@ namespace XF.Material.Forms.UI
         {
             var titleView = page.GetValue(TitleViewProperty);
 
-            if (titleView != null && !(titleView is TitleLabel))
+            if (titleView != null && titleView.GetType() != typeof(TitleLabel))
+            {
                 return;
-
-            var currentTitleView = titleView as TitleLabel;
+            }
 
             var textAlignment = (TextAlignment)page.GetValue(AppBarTitleTextAlignmentProperty);
             var fontFamily = (string)page.GetValue(AppBarTitleTextFontFamilyProperty);
             var fontSize = (double)page.GetValue(AppBarTitleTextFontSizeProperty);
 
-            if (currentTitleView != null)
+            if (titleView is TitleLabel currentTitleView)
             {
                 currentTitleView.HorizontalTextAlignment = textAlignment;
                 currentTitleView.FontFamily = fontFamily;

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -242,6 +242,8 @@ namespace XF.Material.Forms.UI
                 ChangeStatusBarColor(page);
             else if (e.PropertyName == AppBarColorProperty.PropertyName)
                 ChangeBarBackgroundColor(page);
+            else if (e.PropertyName == AppBarTitleTextColorProperty.PropertyName)
+                ChangeBarTextColor(page);
             else if (e.PropertyName == AppBarTitleTextFontFamilyProperty.PropertyName)
                 ChangeFont(page);
             else if (e.PropertyName == AppBarTitleTextFontSizeProperty.PropertyName)

--- a/XF.Material/UI/MaterialNavigationPage.cs
+++ b/XF.Material/UI/MaterialNavigationPage.cs
@@ -341,7 +341,12 @@ namespace XF.Material.Forms.UI
 
         private void ChangeFont(Page page)
         {
-            var currentTitleView = (TitleLabel)page.GetValue(TitleViewProperty);
+            var titleView = page.GetValue(TitleViewProperty);
+
+            if (titleView != null && !(titleView is TitleLabel))
+                return;
+
+            var currentTitleView = titleView as TitleLabel;
 
             var textAlignment = (TextAlignment)page.GetValue(AppBarTitleTextAlignmentProperty);
             var fontFamily = (string)page.GetValue(AppBarTitleTextFontFamilyProperty);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
Overwriting the TitleView property of MaterialNavigationPage throws an InvalidCastException.

### :boom: Does this PR introduce a breaking change?
No, this is not a breaking change.
