### PR TITLE
Fix the helper text of TextField when changing from error state to normal state  and removing the E…

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -894,6 +894,7 @@ namespace XF.Material.Forms.UI
                 if (string.IsNullOrEmpty(ErrorText))
                 {
                     helper.TextColor = HelperTextColor;
+                    helper.Text = HelperText;
                 }
                 else
                 {


### PR DESCRIPTION
…rror Text

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
Currently, if the MaterialTextField is changing from Error state to normal state, and at the same time if Error Text property value is empty, then the Helper text will get the prior error text.

### :new: What is the new behavior (if this is a feature change)?
When changing to the normal state, it should show correct helper text (if any).

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
When HasError is changing from True to False, and setting Error Text to string.Empty. Currently, the helper text will show the error text.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guidelines 
- [ N/A] Relevant documentation was updated
- [ X] Rebased onto current develop
