### PR TITLE
Fix underline on page load

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -779,7 +779,7 @@ namespace XF.Material.Forms.UI
 
                     if (ShouldAnimateUnderline)
                     {
-                        underline.Color = HasError ? ErrorColor : TintColor;
+                        underline.Color = HasError ? ErrorColor : UnderlineColor;
                         underline.HeightRequest = 1;
                         anim.Add(0.0, AnimationDuration, new Animation(v => underline.WidthRequest = v, 0, Width, _animationCurve, () => underline.HorizontalOptions = LayoutOptions.FillAndExpand));
                     }


### PR DESCRIPTION
✨ What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug Fix

⤵️ What is the current behavior?
Tint color applies if bound to a value

🆕 What is the new behavior (if this is a feature change)?
Underline color apples as expected

💥 Does this PR introduce a breaking change?
No

🐛 Recommendations for testing
Bind to a value at page load

📝 Links to relevant issues/docs
Bug #265

🤔 Checklist before submitting
[X ] All projects build
[ X] Follows style guide lines
[X ] Relevant documentation was updated
[X ] Rebased onto current develop

Re-doing PR since it wasn't off of develop