### PR TITLE
Update the LeadingIcon bindable property from string type to ImageSou…

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -98,7 +98,7 @@ namespace XF.Material.Forms.UI
 
         public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(MaterialTextField), false);
 
-        public static readonly BindableProperty LeadingIconProperty = BindableProperty.Create(nameof(LeadingIcon), typeof(string), typeof(MaterialTextField));
+        public static readonly BindableProperty LeadingIconProperty = BindableProperty.Create(nameof(LeadingIcon), typeof(ImageSource), typeof(MaterialTextField));
 
         public static readonly BindableProperty LeadingIconTintColorProperty = BindableProperty.Create(nameof(LeadingIconTintColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#99000000"));
 
@@ -383,9 +383,9 @@ namespace XF.Material.Forms.UI
         /// <summary>
         /// Gets or sets the image source of the icon to be showed at the left side of this text field.
         /// </summary>
-        public string LeadingIcon
+        public ImageSource LeadingIcon
         {
-            get => (string)GetValue(LeadingIconProperty);
+            get => (ImageSource)GetValue(LeadingIconProperty);
             set => SetValue(LeadingIconProperty, value);
         }
 
@@ -1201,9 +1201,9 @@ namespace XF.Material.Forms.UI
             entry.Keyboard = Keyboard.Create(flags);
         }
 
-        private void OnLeadingIconChanged(string icon)
+        private void OnLeadingIconChanged(ImageSource imageSource)
         {
-            leadingIcon.Source = icon;
+            leadingIcon.Source = imageSource;
             OnLeadingIconTintColorChanged(LeadingIconTintColor);
         }
 


### PR DESCRIPTION
Update the LeadingIcon bindable property from string type to ImageSource type to allow it to bind with any kind of Image Source

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature update

### :arrow_heading_down: What is the current behavior?
Currently, the LeadingIcon property of TextField control is String type. So it can only accept FileImageSource (by the TypeConverter implicitly). 

### :new: What is the new behavior (if this is a feature change)?
By updating it from String type to ImageSource type, it will allow the property to bind with any type of ImageSource, like the very popular FontIcons or embedded image sources.

### :boom: Does this PR introduce a breaking change?
No. it still accepts FileImageSource. So it will not have any breaking changes to existing usage of the control.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
