### PR TITLE
Fix the issue of TextField KeyboardFlag reset after InputType changed

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1165,6 +1165,10 @@ namespace XF.Material.Forms.UI
                     break;
             }
 
+            //Need to reset the keyboard flags after the entry Keyboard is set.
+            //Otherwise it will ignore those flags settings.
+            OnKeyboardFlagsChanged(IsAutoCapitalizationEnabled, IsSpellCheckEnabled, IsTextPredictionEnabled, IsTextAllCaps);
+
             // Hint: Will use this for MaterialTextArea
             // entry.AutoSize = inputType == MaterialTextFieldInputType.MultiLine ? EditorAutoSizeOption.TextChanges : EditorAutoSizeOption.Disabled;
             _gridContainer.InputTransparent = inputType == MaterialTextFieldInputType.Choice;

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -98,7 +98,7 @@ namespace XF.Material.Forms.UI
 
         public static readonly BindableProperty IsTextPredictionEnabledProperty = BindableProperty.Create(nameof(IsTextPredictionEnabled), typeof(bool), typeof(MaterialTextField), false);
 
-        public static readonly BindableProperty LeadingIconProperty = BindableProperty.Create(nameof(LeadingIcon), typeof(string), typeof(MaterialTextField));
+        public static readonly BindableProperty LeadingIconProperty = BindableProperty.Create(nameof(LeadingIcon), typeof(ImageSource), typeof(MaterialTextField));
 
         public static readonly BindableProperty LeadingIconTintColorProperty = BindableProperty.Create(nameof(LeadingIconTintColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#99000000"));
 
@@ -383,9 +383,9 @@ namespace XF.Material.Forms.UI
         /// <summary>
         /// Gets or sets the image source of the icon to be showed at the left side of this text field.
         /// </summary>
-        public string LeadingIcon
+        public ImageSource LeadingIcon
         {
-            get => (string)GetValue(LeadingIconProperty);
+            get => (ImageSource)GetValue(LeadingIconProperty);
             set => SetValue(LeadingIconProperty, value);
         }
 
@@ -1201,9 +1201,9 @@ namespace XF.Material.Forms.UI
             entry.Keyboard = Keyboard.Create(flags);
         }
 
-        private void OnLeadingIconChanged(string icon)
+        private void OnLeadingIconChanged(ImageSource imageSource)
         {
-            leadingIcon.Source = icon;
+            leadingIcon.Source = imageSource;
             OnLeadingIconTintColorChanged(LeadingIconTintColor);
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix. The issue was only happening to me on Android.

### :arrow_heading_down: What is the current behavior?
When setting InputType property to any value, the KeyboardFlags will be reset.
For example, if the IsAutoCapitalizationEnabled is false (default value), and when set the InputType to "Password", then it will be changed to have the first letter capitalized.

### :new: What is the new behavior (if this is a feature change)?
Setting InputType property value will not update any KeyboardFlags.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
1. Add a MaterialTextField on a page, and set the InputType to any value (Password, Email etc...)
2. Check the keyboard on Android. The flag was changed to first letter capitalized.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X] All projects build
- [ X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
