### PR TITLE
Update the TextField control to have choice result that might be different from the choice list

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1185,10 +1185,6 @@ namespace XF.Material.Forms.UI
                     break;
             }
 
-            //Need to reset the keyboard flags after the entry Keyboard is set.
-            //Otherwise it will ignore those flags settings.
-            OnKeyboardFlagsChanged(IsAutoCapitalizationEnabled, IsSpellCheckEnabled, IsTextPredictionEnabled, IsTextAllCaps);
-
             // Hint: Will use this for MaterialTextArea
             // entry.AutoSize = inputType == MaterialTextFieldInputType.MultiLine ? EditorAutoSizeOption.TextChanges : EditorAutoSizeOption.Disabled;
             _gridContainer.InputTransparent = inputType == MaterialTextFieldInputType.Choice;

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1136,9 +1136,9 @@ namespace XF.Material.Forms.UI
             helper.FontFamily = counter.FontFamily = fontFamily;
         }
 
-        private void OnInputTypeChanged(MaterialTextFieldInputType inputType)
+        private void OnInputTypeChanged()
         {
-            switch (inputType)
+            switch (InputType)
             {
                 case MaterialTextFieldInputType.Chat:
                     entry.Keyboard = Keyboard.Chat;
@@ -1156,8 +1156,31 @@ namespace XF.Material.Forms.UI
                     entry.Keyboard = Keyboard.Numeric;
                     break;
 
+                //Only when plain type of keyboard we need consider the keyboard flags
+                //Same as Xamarin.Forms.Entry control
                 case MaterialTextFieldInputType.Plain:
-                    entry.Keyboard = Keyboard.Plain;
+                    var flags = KeyboardFlags.None;
+                    if (IsTextAllCaps)
+                    {
+                        flags |= KeyboardFlags.CapitalizeCharacter;
+                    }
+
+                    if (IsAutoCapitalizationEnabled && !IsTextAllCaps)
+                    {
+                        flags |= KeyboardFlags.CapitalizeWord;
+                    }
+
+                    if (IsSpellCheckEnabled)
+                    {
+                        flags |= KeyboardFlags.Spellcheck;
+                    }
+
+                    if (IsTextPredictionEnabled)
+                    {
+                        flags |= KeyboardFlags.Suggestions;
+                    }
+
+                    entry.Keyboard = Keyboard.Create(flags);
                     break;
 
                 case MaterialTextFieldInputType.Telephone:
@@ -1187,38 +1210,11 @@ namespace XF.Material.Forms.UI
 
             // Hint: Will use this for MaterialTextArea
             // entry.AutoSize = inputType == MaterialTextFieldInputType.MultiLine ? EditorAutoSizeOption.TextChanges : EditorAutoSizeOption.Disabled;
-            _gridContainer.InputTransparent = inputType == MaterialTextFieldInputType.Choice;
-            trailingIcon.IsVisible = inputType == MaterialTextFieldInputType.Choice;
+            _gridContainer.InputTransparent = InputType == MaterialTextFieldInputType.Choice;
+            trailingIcon.IsVisible = InputType == MaterialTextFieldInputType.Choice;
 
-            entry.IsNumericKeyboard = inputType == MaterialTextFieldInputType.Telephone || inputType == MaterialTextFieldInputType.Numeric;
-            entry.IsPassword = inputType == MaterialTextFieldInputType.Password || inputType == MaterialTextFieldInputType.NumericPassword;
-        }
-
-        private void OnKeyboardFlagsChanged(bool isAutoCapitalizationEnabled, bool isSpellCheckEnabled, bool isTextPredictionEnabled, bool isTextAllCaps)
-        {
-            var flags = KeyboardFlags.None;
-
-            if (isTextAllCaps)
-            {
-                flags |= KeyboardFlags.CapitalizeCharacter;
-            }
-
-            if (isAutoCapitalizationEnabled && !isTextAllCaps)
-            {
-                flags |= KeyboardFlags.CapitalizeWord;
-            }
-
-            if (isSpellCheckEnabled)
-            {
-                flags |= KeyboardFlags.Spellcheck;
-            }
-
-            if (isTextPredictionEnabled)
-            {
-                flags |= KeyboardFlags.Suggestions;
-            }
-
-            entry.Keyboard = Keyboard.Create(flags);
+            entry.IsNumericKeyboard = InputType == MaterialTextFieldInputType.Telephone || InputType == MaterialTextFieldInputType.Numeric;
+            entry.IsPassword = InputType == MaterialTextFieldInputType.Password || InputType == MaterialTextFieldInputType.NumericPassword;
         }
 
         private void OnLeadingIconChanged(ImageSource imageSource)
@@ -1372,12 +1368,6 @@ namespace XF.Material.Forms.UI
 
         private void SetPropertyChangeHandler(ref Dictionary<string, Action> propertyChangeActions)
         {
-            Action keyboardFlagsAction = () => OnKeyboardFlagsChanged(
-                IsAutoCapitalizationEnabled,
-                IsSpellCheckEnabled,
-                IsTextPredictionEnabled,
-                IsTextAllCaps);
-
             propertyChangeActions = new Dictionary<string, Action>
             {
                 { nameof(Text), () => OnTextChanged(Text) },
@@ -1390,7 +1380,6 @@ namespace XF.Material.Forms.UI
                 { nameof(HelperText), () => OnHelperTextChanged(HelperText) },
                 { nameof(HelperTextFontFamily), () => OnHelpertTextFontFamilyChanged(HelperTextFontFamily) },
                 { nameof(HelperTextColor), () => OnHelperTextColorChanged(HelperTextColor) },
-                { nameof(InputType), () => OnInputTypeChanged(InputType) },
                 { nameof(IsEnabled), () => OnEnabledChanged(IsEnabled) },
                 { nameof(BackgroundColor), () => OnBackgroundColorChanged(BackgroundColor) },
                 { nameof(AlwaysShowUnderline), () => OnAlwaysShowUnderlineChanged(AlwaysShowUnderline) },
@@ -1405,10 +1394,11 @@ namespace XF.Material.Forms.UI
                 { nameof(Choices), () => OnChoicesChanged(Choices) },
                 { nameof(LeadingIcon), () => OnLeadingIconChanged(LeadingIcon) },
                 { nameof(LeadingIconTintColor), () => OnLeadingIconTintColorChanged(LeadingIconTintColor) },
-                { nameof(IsSpellCheckEnabled), keyboardFlagsAction },
-                { nameof(IsTextPredictionEnabled), keyboardFlagsAction },
-                { nameof(IsAutoCapitalizationEnabled), keyboardFlagsAction },
-                { nameof(IsTextAllCaps), keyboardFlagsAction },
+                { nameof(InputType), () => OnInputTypeChanged() },
+                { nameof(IsSpellCheckEnabled), () => OnInputTypeChanged() },
+                { nameof(IsTextPredictionEnabled), () => OnInputTypeChanged() },
+                { nameof(IsAutoCapitalizationEnabled), () => OnInputTypeChanged() },
+                { nameof(IsTextAllCaps), () => OnInputTypeChanged() },
                 { nameof(TextFontSize), () => OnTextFontSizeChanged(TextFontSize) },
                 { nameof(ErrorText), () => OnErrorTextChanged() }
             };

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -54,7 +54,7 @@ namespace XF.Material.Forms.UI
                     if (control._selectedIndex != index)
                     {
                         control._selectedIndex = index;
-                        control.Text = control._choices[index];
+                        control.Text = control._choicesResults[index];
                         control.AnimateToInactiveOrFocusedStateOnStart(control);
 
                         control.UpdateCounter();
@@ -140,6 +140,7 @@ namespace XF.Material.Forms.UI
         private readonly Easing _animationCurve = Easing.SinOut;
         private readonly Dictionary<string, Action> _propertyChangeActions;
         private IList<string> _choices;
+        private IList<string> _choicesResults;
         private bool _counterEnabled;
         private DisplayInfo _lastDeviceDisplay;
         private int _selectedIndex = -1;
@@ -488,6 +489,8 @@ namespace XF.Material.Forms.UI
         }
 
         public string ChoicesBindingName { get; set; }
+
+        public string ChoicesResultBindingName { get; set; }
 
         //public string ChoicesBindingName
         //{
@@ -1001,31 +1004,40 @@ namespace XF.Material.Forms.UI
             UpdateCounter();
         }
 
-        private IList<string> GetChoices()
+        private IList<string> GetChoices(out IList<string> choicesResults)
         {
             var choiceStrings = new List<string>(Choices.Count);
+            choicesResults = new List<string>(Choices.Count);
             var listType = Choices[0].GetType();
             foreach (var item in Choices)
             {
+                string choice = item.ToString();
                 if (!string.IsNullOrEmpty(ChoicesBindingName))
                 {
                     var propInfo = listType.GetProperty(ChoicesBindingName);
 
-                    if (propInfo == null)
-                    {
-                        System.Diagnostics.Debug.WriteLine($"Property {ChoicesBindingName} was not found for item in {Choices}.");
-                        choiceStrings.Add(item.ToString());
+                    if (propInfo != null)
+                    { 
+                        var propValue = propInfo.GetValue(item);
+                        choice =propValue.ToString();
                     }
-                    else
+                }
+
+                choiceStrings.Add(choice);
+
+                string choiceResult = choice;
+                if (!string.IsNullOrEmpty(ChoicesResultBindingName))
+                {
+                    var propInfo = listType.GetProperty(ChoicesResultBindingName);
+
+                    if (propInfo != null)
                     {
                         var propValue = propInfo.GetValue(item);
-                        choiceStrings.Add(propValue.ToString());
+                        choiceResult = propValue.ToString();
                     }
                 }
-                else
-                {
-                    choiceStrings.Add(item.ToString());
-                }
+
+                choicesResults.Add(choiceResult);
             }
 
             return choiceStrings;
@@ -1054,7 +1066,15 @@ namespace XF.Material.Forms.UI
 
         private void OnChoicesChanged(ICollection choices)
         {
-            _choices = choices?.Count > 0 ? GetChoices() : null;
+            if (choices?.Count > 0)
+            {
+                _choices = GetChoices(out _choicesResults);
+            }
+            else
+            {
+                _choices = null;
+                _choicesResults = null;
+            }
         }
 
         private void OnEnabledChanged(bool isEnabled)
@@ -1258,7 +1278,7 @@ namespace XF.Material.Forms.UI
             {
                 throw new InvalidOperationException("The property `Choices` is null or empty");
             }
-            _choices = GetChoices();
+            _choices = GetChoices(out _choicesResults);
 
             var title = MaterialConfirmationDialog.GetDialogTitle(this);
             var confirmingText = MaterialConfirmationDialog.GetDialogConfirmingText(this);
@@ -1278,14 +1298,14 @@ namespace XF.Material.Forms.UI
             if (result >= 0)
             {
                 _selectedIndex = result;
-                Text = _choices[result];
+                Text = _choicesResults[result];
                 // entry.Text = Text;
             }
         }
 
         private void OnTextChanged(string text)
         {
-            if (InputType == MaterialTextFieldInputType.Choice && !string.IsNullOrEmpty(text) && _choices?.Contains(text) == false)
+            if (InputType == MaterialTextFieldInputType.Choice && !string.IsNullOrEmpty(text) && _choicesResults?.Contains(text) == false)
             {
                 Debug.WriteLine($"The `Text` property value `{Text}` does not match any item in the collection `Choices`.");
                 Text = null;


### PR DESCRIPTION
Update the TextField control to have choice result that might be different from the choice list

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Currently, the choice type of TextField has 'ChoicesBindingName' property to specify the values for user to select from in the list of a radio group. When the user choose an item from the list, the TextField will show the value from the property value.

### :new: What is the new behavior (if this is a feature change)?
A new property "ChoicesResultBindingName" was added to allow users to specify the values to show in the TextField. If "ChoicesResultBindingName" is not provided, then it will have the exactly same behavior as before.

A typical use case: show the Country Name list for user to choose, and then show the country international phone code (e.g "+61" for Australia) in the TextField.

### :boom: Does this PR introduce a breaking change?
No. If "ChoicesResultBindingName" is not provided, then it will have the exactly same behavior as before.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X ] All projects build
- [X ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
