### PR TITLE
Update MaterialInputDialog.xaml.cs

### DIFF
--- a/XF.Material/UI/Dialogs/MaterialInputDialog.xaml
+++ b/XF.Material/UI/Dialogs/MaterialInputDialog.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <local:BaseMaterialModalPage x:Class="XF.Material.Forms.UI.Dialogs.MaterialInputDialog"
                              xmlns="http://xamarin.com/schemas/2014/forms"
                              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -8,7 +8,8 @@
                              BackgroundColor="#51000000"
                              CloseWhenBackgroundIsClicked="True">
     <ContentPage.Content>
-        <material:MaterialCard x:Name="Container"
+        <ScrollView>
+            <material:MaterialCard x:Name="Container"
                                Margin="{DynamicResource Material.Dialog.Margin}"
                                Padding="0"
                                BackgroundColor="White"
@@ -19,90 +20,91 @@
                                IsClippedToBounds="True"
                                VerticalOptions="Center"
                                WidthRequest="{StaticResource Material.Dialog.Width}">
-            <Grid RowSpacing="0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <material:MaterialLabel x:Name="DialogTitle"
+                <Grid RowSpacing="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <material:MaterialLabel x:Name="DialogTitle"
                                         Grid.Row="0"
                                         Margin="24,20,24,12"
                                         TextColor="#DE000000"
                                         TypeScale="H6"
                                         VerticalOptions="Start">
-                    <Label.Triggers>
-                        <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
-                            <Setter Property="IsVisible" Value="False" />
-                        </Trigger>
-                        <Trigger TargetType="Label" Property="Text" Value="{x:Static sys:String.Empty}">
-                            <Setter Property="IsVisible" Value="False" />
-                        </Trigger>
-                    </Label.Triggers>
-                </material:MaterialLabel>
-                <material:MaterialLabel x:Name="Message"
+                        <Label.Triggers>
+                            <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                                <Setter Property="IsVisible" Value="False" />
+                            </Trigger>
+                            <Trigger TargetType="Label" Property="Text" Value="{x:Static sys:String.Empty}">
+                                <Setter Property="IsVisible" Value="False" />
+                            </Trigger>
+                        </Label.Triggers>
+                    </material:MaterialLabel>
+                    <material:MaterialLabel x:Name="Message"
                                         Grid.Row="1"
                                         Margin="24,0,24,16"
                                         Text="Lorem ipsum dolor sit amet, conse tetuer adipiscing elit. Aenean commodo ligula eget dolor."
                                         TextColor="#99000000"
                                         TypeScale="Body1">
-                    <Label.Triggers>
-                        <DataTrigger Binding="{Binding Source={x:Reference DialogTitle}, Path=IsVisible}"
+                        <Label.Triggers>
+                            <DataTrigger Binding="{Binding Source={x:Reference DialogTitle}, Path=IsVisible}"
                                      TargetType="Label"
                                      Value="False">
-                            <Setter Property="Margin" Value="24, 20, 24, 16" />
-                        </DataTrigger>
-                        <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
-                            <Setter Property="IsVisible" Value="False" />
-                        </Trigger>
-                        <Trigger TargetType="Label" Property="Text" Value="{x:Static sys:String.Empty}">
-                            <Setter Property="IsVisible" Value="False" />
-                        </Trigger>
-                    </Label.Triggers>
-                </material:MaterialLabel>
-                <material:MaterialTextField x:Name="TextField"
+                                <Setter Property="Margin" Value="24, 20, 24, 16" />
+                            </DataTrigger>
+                            <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
+                                <Setter Property="IsVisible" Value="False" />
+                            </Trigger>
+                            <Trigger TargetType="Label" Property="Text" Value="{x:Static sys:String.Empty}">
+                                <Setter Property="IsVisible" Value="False" />
+                            </Trigger>
+                        </Label.Triggers>
+                    </material:MaterialLabel>
+                    <material:MaterialTextField x:Name="TextField"
                                             Grid.Row="2"
                                             Margin="24,0,24,0"
                                             AlwaysShowUnderline="True"
                                             BackgroundColor="Transparent"
                                             FloatingPlaceholderEnabled="False"
                                             HorizontalPadding="0" />
-                <Grid Grid.Row="3"
+                    <Grid Grid.Row="3"
                       Margin="0,20,8,0"
                       ColumnSpacing="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="52" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <material:MaterialButton x:Name="NegativeButton"
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="52" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <material:MaterialButton x:Name="NegativeButton"
                                              Grid.Column="2"
                                              Margin="0,0,-8,0"
                                              ButtonType="Text"
                                              VerticalOptions="Center">
-                        <material:MaterialButton.Triggers>
-                            <Trigger TargetType="Button" Property="Text" Value="{x:Null}">
-                                <Setter Property="IsVisible" Value="False" />
-                                <Setter Property="IsEnabled" Value="False" />
-                            </Trigger>
-                            <Trigger TargetType="Button" Property="Text" Value="{x:Static sys:String.Empty}">
-                                <Setter Property="IsVisible" Value="False" />
-                                <Setter Property="IsEnabled" Value="False" />
-                            </Trigger>
-                        </material:MaterialButton.Triggers>
-                    </material:MaterialButton>
-                    <material:MaterialButton x:Name="PositiveButton"
+                            <material:MaterialButton.Triggers>
+                                <Trigger TargetType="Button" Property="Text" Value="{x:Null}">
+                                    <Setter Property="IsVisible" Value="False" />
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </Trigger>
+                                <Trigger TargetType="Button" Property="Text" Value="{x:Static sys:String.Empty}">
+                                    <Setter Property="IsVisible" Value="False" />
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </Trigger>
+                            </material:MaterialButton.Triggers>
+                        </material:MaterialButton>
+                        <material:MaterialButton x:Name="PositiveButton"
                                              Grid.Column="3"
                                              ButtonType="Text"
                                              IsEnabled="False"
                                              VerticalOptions="Center" />
+                    </Grid>
                 </Grid>
-            </Grid>
-        </material:MaterialCard>
+            </material:MaterialCard>
+        </ScrollView>
     </ContentPage.Content>
 </local:BaseMaterialModalPage>

--- a/XF.Material/UI/Dialogs/MaterialInputDialog.xaml.cs
+++ b/XF.Material/UI/Dialogs/MaterialInputDialog.xaml.cs
@@ -44,7 +44,7 @@ namespace XF.Material.Forms.UI.Dialogs
         {
             var dialog = new MaterialInputDialog(title, message, inputText, inputPlaceholder, confirmingText,
                 dismissiveText, configuration)
-            { PositiveButton = { IsEnabled = false } };
+            { PositiveButton = { IsEnabled = !string.IsNullOrEmpty(inputText) } };
 
             await dialog.ShowAsync();
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix for a situation, when InputDialog recieves some input text, text is complete, but a PositiveButton is inactive. For an example a password restore procedure, a user fills login, cant login and press remind password, an input dialog has been opened with passed login as an inputText, and if login is complete, the PositiveButton  is inactive.

### :arrow_heading_down: What is the current behavior?
When passed an input text, the PositiveButton is inactive

### :new: What is the new behavior (if this is a feature change)?
the PositiveButton is active if passed an inputText. In the future, there are must be an ability attach some event handler, for control activity of the PositiveButton in text changed event.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Сhanges are negligible, no need in testing.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
