### PR TITLE
Fix password type entry always has first character upper case issue, and add a new property to set the linebreakmode of placeholder 

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml
+++ b/XF.Material/UI/MaterialTextField.xaml
@@ -1,24 +1,23 @@
 ﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ContentView x:Class="XF.Material.Forms.UI.MaterialTextField"
-             xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:internal="clr-namespace:XF.Material.Forms.UI.Internals"
-             xmlns:material="clr-namespace:XF.Material.Forms.UI">
+<ContentView
+    x:Class="XF.Material.Forms.UI.MaterialTextField"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:internal="clr-namespace:XF.Material.Forms.UI.Internals"
+    xmlns:material="clr-namespace:XF.Material.Forms.UI">
     <View.GestureRecognizers>
-        <TapGestureRecognizer x:Name="mainTapGesture"
-                              NumberOfTapsRequired="1" />
+        <TapGestureRecognizer x:Name="mainTapGesture" NumberOfTapsRequired="1" />
     </View.GestureRecognizers>
     <ContentView.Content>
-        <Grid x:Name="_gridContainer"
-              ColumnSpacing="0"
-              RowSpacing="0">
+        <Grid
+            x:Name="_gridContainer"
+            ColumnSpacing="0"
+            RowSpacing="0">
             <View.GestureRecognizers>
-                <TapGestureRecognizer x:Name="tapGesture"
-                                      NumberOfTapsRequired="1" />
+                <TapGestureRecognizer x:Name="tapGesture" NumberOfTapsRequired="1" />
             </View.GestureRecognizers>
             <Grid.RowDefinitions>
-                <RowDefinition x:Name="_autoSizingRow"
-                               Height="56" />
+                <RowDefinition x:Name="_autoSizingRow" Height="56" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
@@ -26,91 +25,102 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <BoxView x:Name="backgroundCard"
-                     Grid.Row="0"
-                     Grid.ColumnSpan="3"
-                     BackgroundColor="#DCDCDC"
-                     CornerRadius="4,4,0,0" />
-            <material:MaterialIcon x:Name="leadingIcon"
-                                   Grid.Row="0"
-                                   Grid.Column="0"
-                                   Margin="12,16,0,16"
-                                   HeightRequest="24"
-                                   VerticalOptions="Start"
-                                   WidthRequest="24">
+            <BoxView
+                x:Name="backgroundCard"
+                Grid.Row="0"
+                Grid.ColumnSpan="3"
+                BackgroundColor="#DCDCDC"
+                CornerRadius="4,4,0,0" />
+            <material:MaterialIcon
+                x:Name="leadingIcon"
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="12,16,0,16"
+                HeightRequest="24"
+                VerticalOptions="Start"
+                WidthRequest="24">
                 <View.Triggers>
                     <Trigger TargetType="material:MaterialIcon" Property="Source" Value="{x:Null}">
                         <Setter Property="IsVisible" Value="False" />
                     </Trigger>
                 </View.Triggers>
             </material:MaterialIcon>
-            <material:MaterialLabel x:Name="placeholder"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Margin="12,0,12,0"
-                                    FontSize="{Binding Source={x:Reference entry}, Path=FontSize}"
-                                    InputTransparent="True"
-                                    Text="Placeholder"
-                                    TextColor="#99000000"
-                                    TypeScale="Body2"
-                                    VerticalOptions="Center"
-                                    VerticalTextAlignment="Center" />
-            <ContentView x:Name="_inputContainer"
-                         Grid.Row="0"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         HorizontalOptions="FillAndExpand"
-                         VerticalOptions="Center">
-                <internal:MaterialEntry x:Name="entry"
-                                        Margin="12,24,12,0"
-                                        FontFamily="{DynamicResource Material.FontFamily.Body2}"
-                                        FontSize="16"
-                                        HorizontalOptions="FillAndExpand"
-                                        IsSpellCheckEnabled="False"
-                                        IsTextPredictionEnabled="False"
-                                        TextColor="#D0000000"
-                                        VerticalOptions="FillAndExpand" />
+            <material:MaterialLabel
+                x:Name="placeholder"
+                Grid.Row="0"
+                Grid.Column="1"
+                Margin="12,0,12,0"
+                FontSize="{Binding Source={x:Reference entry}, Path=FontSize}"
+                InputTransparent="True"
+                LineBreakMode="TailTruncation"
+                Text="Placeholder"
+                TextColor="#99000000"
+                TypeScale="Body2"
+                VerticalOptions="Center"
+                VerticalTextAlignment="Center" />
+            <ContentView
+                x:Name="_inputContainer"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.ColumnSpan="2"
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="Center">
+                <internal:MaterialEntry
+                    x:Name="entry"
+                    Margin="12,24,12,0"
+                    FontFamily="{DynamicResource Material.FontFamily.Body2}"
+                    FontSize="16"
+                    HorizontalOptions="FillAndExpand"
+                    IsSpellCheckEnabled="False"
+                    IsTextPredictionEnabled="False"
+                    TextColor="#D0000000"
+                    VerticalOptions="FillAndExpand" />
                 <ContentView.Triggers>
-                    <DataTrigger Binding="{Binding Source={x:Reference trailingIcon}, Path=IsVisible}"
-                                 TargetType="ContentView"
-                                 Value="True">
+                    <DataTrigger
+                        Binding="{Binding Source={x:Reference trailingIcon}, Path=IsVisible}"
+                        TargetType="ContentView"
+                        Value="True">
                         <Setter Property="Grid.ColumnSpan" Value="1" />
                     </DataTrigger>
                 </ContentView.Triggers>
             </ContentView>
-            <BoxView x:Name="persistentUnderline"
-                     Grid.Row="0"
-                     Grid.ColumnSpan="3"
-                     Margin="0,0,0,-1"
-                     HeightRequest="1"
-                     HorizontalOptions="FillAndExpand"
-                     IsVisible="False"
-                     VerticalOptions="End"
-                     Color="{Binding Source={x:Reference underline}, Path=Color}" />
-            <BoxView x:Name="underline"
-                     Grid.Row="0"
-                     Grid.ColumnSpan="3"
-                     Margin="0,0,0,-1"
-                     HeightRequest="2"
-                     HorizontalOptions="Center"
-                     VerticalOptions="End"
-                     WidthRequest="0" />
-            <material:MaterialIcon x:Name="trailingIcon"
-                                   Grid.Row="0"
-                                   Grid.Column="2"
-                                   Margin="0,16,12,16"
-                                   HeightRequest="24"
-                                   IsVisible="False"
-                                   Source="xf_arrow_dropdown"
-                                   VerticalOptions="Start"
-                                   WidthRequest="24" />
-            <material:MaterialLabel x:Name="helper"
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    Grid.ColumnSpan="3"
-                                    Margin="12,4,12,0"
-                                    TextColor="#99000000"
-                                    TypeScale="Caption">
+            <BoxView
+                x:Name="persistentUnderline"
+                Grid.Row="0"
+                Grid.ColumnSpan="3"
+                Margin="0,0,0,-1"
+                HeightRequest="1"
+                HorizontalOptions="FillAndExpand"
+                IsVisible="False"
+                VerticalOptions="End"
+                Color="{Binding Source={x:Reference underline}, Path=Color}" />
+            <BoxView
+                x:Name="underline"
+                Grid.Row="0"
+                Grid.ColumnSpan="3"
+                Margin="0,0,0,-1"
+                HeightRequest="2"
+                HorizontalOptions="Center"
+                VerticalOptions="End"
+                WidthRequest="0" />
+            <material:MaterialIcon
+                x:Name="trailingIcon"
+                Grid.Row="0"
+                Grid.Column="2"
+                Margin="0,16,12,16"
+                HeightRequest="24"
+                IsVisible="False"
+                Source="xf_arrow_dropdown"
+                VerticalOptions="Start"
+                WidthRequest="24" />
+            <material:MaterialLabel
+                x:Name="helper"
+                Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="3"
+                Margin="12,4,12,0"
+                TextColor="#99000000"
+                TypeScale="Caption">
                 <Label.Triggers>
                     <Trigger TargetType="Label" Property="Text" Value="">
                         <Setter Property="IsVisible" Value="False" />
@@ -118,20 +128,22 @@
                     <Trigger TargetType="Label" Property="Text" Value="{x:Null}">
                         <Setter Property="IsVisible" Value="False" />
                     </Trigger>
-                    <DataTrigger Binding="{Binding Source={x:Reference counter}, Path=IsVisible}"
-                                 TargetType="Label"
-                                 Value="True">
+                    <DataTrigger
+                        Binding="{Binding Source={x:Reference counter}, Path=IsVisible}"
+                        TargetType="Label"
+                        Value="True">
                         <Setter Property="Grid.ColumnSpan" Value="2" />
                     </DataTrigger>
                 </Label.Triggers>
             </material:MaterialLabel>
-            <material:MaterialLabel x:Name="counter"
-                                    Grid.Row="1"
-                                    Grid.Column="2"
-                                    Margin="0,4,12,0"
-                                    HorizontalOptions="End"
-                                    TextColor="#99000000"
-                                    TypeScale="Caption">
+            <material:MaterialLabel
+                x:Name="counter"
+                Grid.Row="1"
+                Grid.Column="2"
+                Margin="0,4,12,0"
+                HorizontalOptions="End"
+                TextColor="#99000000"
+                TypeScale="Caption">
                 <Label.Triggers>
                     <Trigger TargetType="Label" Property="Text" Value="">
                         <Setter Property="IsVisible" Value="False" />

--- a/XF.Material/UI/MaterialTextField.xaml
+++ b/XF.Material/UI/MaterialTextField.xaml
@@ -51,6 +51,7 @@
                                     Margin="12,0,12,0"
                                     FontSize="{Binding Source={x:Reference entry}, Path=FontSize}"
                                     InputTransparent="True"
+                                    LineBreakMode="TailTruncation"
                                     Text=""
                                     TextColor="#99000000"
                                     TypeScale="Body2"

--- a/XF.Material/UI/MaterialTextField.xaml
+++ b/XF.Material/UI/MaterialTextField.xaml
@@ -45,33 +45,35 @@
                     </Trigger>
                 </View.Triggers>
             </material:MaterialIcon>
-            <material:MaterialLabel x:Name="placeholder"
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Margin="12,0,12,0"
-                                    FontSize="{Binding Source={x:Reference entry}, Path=FontSize}"
-                                    InputTransparent="True"
-                                    LineBreakMode="TailTruncation"
-                                    Text=""
-                                    TextColor="#99000000"
-                                    TypeScale="Body2"
-                                    VerticalOptions="Center"
-                                    VerticalTextAlignment="Center" />
-            <ContentView x:Name="_inputContainer"
-                         Grid.Row="0"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         HorizontalOptions="FillAndExpand"
-                         VerticalOptions="Center">
-                <internal:MaterialEntry x:Name="entry"
-                                        Margin="12,24,12,0"
-                                        FontFamily="{DynamicResource Material.FontFamily.Body2}"
-                                        FontSize="16"
-                                        HorizontalOptions="FillAndExpand"
-                                        IsSpellCheckEnabled="False"
-                                        IsTextPredictionEnabled="False"
-                                        TextColor="#D0000000"
-                                        VerticalOptions="FillAndExpand" />
+            <material:MaterialLabel
+                x:Name="placeholder"
+                Grid.Row="0"
+                Grid.Column="1"
+                Margin="12,0,12,0"
+                FontSize="{Binding Source={x:Reference entry}, Path=FontSize}"
+                InputTransparent="True"
+                Text=""
+                TextColor="#99000000"
+                TypeScale="Body2"
+                VerticalOptions="Center"
+                VerticalTextAlignment="Center" />
+            <ContentView
+                x:Name="_inputContainer"
+                Grid.Row="0"
+                Grid.Column="1"
+                Grid.ColumnSpan="2"
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="Center">
+                <internal:MaterialEntry
+                    x:Name="entry"
+                    Margin="12,24,12,0"
+                    FontFamily="{DynamicResource Material.FontFamily.Body2}"
+                    FontSize="16"
+                    HorizontalOptions="FillAndExpand"
+                    IsSpellCheckEnabled="False"
+                    IsTextPredictionEnabled="False"
+                    TextColor="#D0000000"
+                    VerticalOptions="FillAndExpand" />
                 <ContentView.Triggers>
                     <DataTrigger
                         Binding="{Binding Source={x:Reference trailingIcon}, Path=IsVisible}"

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -134,6 +134,8 @@ namespace XF.Material.Forms.UI
 
         public static readonly BindableProperty UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#99000000"));
 
+        public static readonly BindableProperty PlaceholderLineBreakModeProperty = BindableProperty.Create(nameof(PlaceholderLineBreakMode), typeof(LineBreakMode), typeof(MaterialTextField), LineBreakMode.WordWrap);
+
         //public static readonly BindableProperty ChoicesBindingNameProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MaterialTextField), string.Empty, BindingMode.TwoWay);
 
         private const double AnimationDuration = 0.35;
@@ -553,6 +555,15 @@ namespace XF.Material.Forms.UI
         {
             get => (Color)GetValue(UnderlineColorProperty);
             set => SetValue(UnderlineColorProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the line break mode for the placeholder
+        /// </summary>
+        public LineBreakMode PlaceholderLineBreakMode
+        {
+            get { return (LineBreakMode)GetValue(PlaceholderLineBreakModeProperty); }
+            set { SetValue(PlaceholderLineBreakModeProperty, value); }
         }
 
         /// <inheritdoc />
@@ -1074,6 +1085,11 @@ namespace XF.Material.Forms.UI
             }
         }
 
+        private void OnPlaceholderLineBreakModeChanged()
+        {
+            placeholder.LineBreakMode = PlaceholderLineBreakMode;
+        }
+
         private void OnFloatingPlaceholderEnabledChanged(bool isEnabled)
         {
             double marginTopVariation = Device.RuntimePlatform == Device.iOS ? 18 : 20;
@@ -1381,7 +1397,8 @@ namespace XF.Material.Forms.UI
                 { nameof(IsAutoCapitalizationEnabled), () => OnInputTypeChanged() },
                 { nameof(IsTextAllCaps), () => OnInputTypeChanged() },
                 { nameof(TextFontSize), () => OnTextFontSizeChanged(TextFontSize) },
-                { nameof(ErrorText), () => OnErrorTextChanged() }
+                { nameof(ErrorText), () => OnErrorTextChanged() },
+                { nameof(PlaceholderLineBreakMode), () => OnPlaceholderLineBreakModeChanged()}
             };
         }
 

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1180,7 +1180,7 @@ namespace XF.Material.Forms.UI
                     break;
 
                 case MaterialTextFieldInputType.Password:
-                    entry.Keyboard = Keyboard.Text;
+                    entry.Keyboard = Keyboard.Plain;
                     break;
 
                 case MaterialTextFieldInputType.Choice:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix and feature

### :arrow_heading_down: What is the current behavior?
Currently, the Password type of TextField always has the first character upper case on Android. 
And the placeholder of TextField always has WordWrap line break mode.

### :new: What is the new behavior (if this is a feature change)?
The Password type of TextField will not automatically have the first character to be uppercase on Android and iOS. 
TextField has a new bindable property "PlaceholderLineBreakMode" to allow the user to set the line break mode for the place holder.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X ] All projects build
- [ X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
