### PR TITLE
Change Image type from string to ImageSource

### DIFF
--- a/XF.Material/Models/MaterialMenuItem.cs
+++ b/XF.Material/Models/MaterialMenuItem.cs
@@ -1,10 +1,12 @@
-﻿namespace XF.Material.Forms.Models
+﻿using Xamarin.Forms;
+
+namespace XF.Material.Forms.Models
 {
     public class MaterialMenuItem
     {
         public string Text { get; set; }
 
-        public string Image { get; set; }
+        public ImageSource Image { get; set; }
 
         internal int Index { get; set; }
     }

--- a/XF.Material/Platforms/Android/ImageSourceExtensions.cs
+++ b/XF.Material/Platforms/Android/ImageSourceExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+namespace XF.Material.Droid
+{
+    public static class ImageSourceExtensions
+    {
+        public static IImageSourceHandler GetImageSourceHandler(this ImageSource source)
+        {
+            return source switch
+            {
+                FileImageSource _ => new FileImageSourceHandler(),
+                StreamImageSource _ => new StreamImagesourceHandler(),
+                FontImageSource _ => new FontImageSourceHandler(),
+                _ => new ImageLoaderSourceHandler(),
+            };
+        }
+    }
+}

--- a/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
@@ -63,6 +63,7 @@ namespace XF.Material.Droid.Renderers
 
             switch (e?.PropertyName)
             {
+                case nameof(MaterialButton.ImageSource):
                 case nameof(MaterialButton.Image):
                     SetButtonIcon();
                     break;
@@ -80,7 +81,7 @@ namespace XF.Material.Droid.Renderers
 
         private void SetButtonIcon()
         {
-            var withIcon = !string.IsNullOrEmpty(_materialButton.Image);
+            var withIcon = !string.IsNullOrEmpty(_materialButton.Image) || !(_materialButton.ImageSource?.IsEmpty ?? true);
             _helper.UpdateHasIcon(withIcon);
 
             if (!withIcon)

--- a/XF.Material/Platforms/Ios/ImageSourceExtensions.cs
+++ b/XF.Material/Platforms/Ios/ImageSourceExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+namespace XF.Material.iOS
+{
+    public static class ImageSourceExtensions
+    {
+        public static IImageSourceHandler GetImageSourceHandler(this ImageSource source)
+        {
+            return source switch
+            {
+                FileImageSource _ => new FileImageSourceHandler(),
+                StreamImageSource _ => new StreamImagesourceHandler(),
+                FontImageSource _ => new FontImageSourceHandler(),
+                _ => new ImageLoaderSourceHandler(),
+            };
+        }
+    }
+}

--- a/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
@@ -298,7 +298,7 @@ namespace XF.Material.iOS.Renderers
             _disabledTextColor = _normalTextColor.GetDisabledColor();
         }
 
-        private void SetupIcon()
+        private async void SetupIcon()
         {
             if (_withIcon)
             {
@@ -312,27 +312,8 @@ namespace XF.Material.iOS.Renderers
                     }
                     else if(!(_materialButton.ImageSource?.IsEmpty ?? true))
                     {
-                        IImageSourceHandler imageSourceHandler = null;
-                        if (_materialButton.ImageSource is UriImageSource)
-                        {
-                            imageSourceHandler = new ImageLoaderSourceHandler();
-                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
-                        }
-                        else if(_materialButton.ImageSource is FileImageSource)
-                        {
-                            imageSourceHandler = new FileImageSourceHandler();
-                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
-                        }
-                        else if (_materialButton.ImageSource is StreamImageSource)
-                        {
-                            imageSourceHandler = new StreamImagesourceHandler();
-                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
-                        }
-                        else if(_materialButton.ImageSource is FontImageSource)
-                        {
-                            imageSourceHandler = new FontImageSourceHandler();
-                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
-                        }
+                        IImageSourceHandler imageSourceHandler = _materialButton.ImageSource.GetImageSourceHandler();
+                        image = await imageSourceHandler.LoadImageAsync(_materialButton.ImageSource);
                     }
                     UIGraphics.BeginImageContextWithOptions(new CGSize(18, 18), false, 0f);
                     image?.Draw(new CGRect(0, 0, 18, 18));

--- a/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
@@ -71,7 +71,7 @@ namespace XF.Material.iOS.Renderers
 
                 if (_materialButton != null)
                 {
-                    _withIcon = _materialButton.Image != null;
+                    _withIcon = _materialButton.Image != null || _materialButton.ImageSource != null && !_materialButton.ImageSource.IsEmpty;
 
                     if (_materialButton.AllCaps)
                     {
@@ -118,6 +118,7 @@ namespace XF.Material.iOS.Renderers
                     await UpdateBackgroundColor();
                     break;
 
+                case nameof(MaterialButton.ImageSource):
                 case nameof(MaterialButton.Image):
                     SetupIcon();
                     UpdateButtonLayer();
@@ -305,8 +306,34 @@ namespace XF.Material.iOS.Renderers
 
                 try
                 {
-                    image = UIImage.FromFile(_materialButton.Image.File) ?? UIImage.FromBundle(_materialButton.Image.File);
-
+                    if (_materialButton.Image != null)
+                    {
+                        image = UIImage.FromFile(_materialButton.Image.File) ?? UIImage.FromBundle(_materialButton.Image.File);
+                    }
+                    else if(!(_materialButton.ImageSource?.IsEmpty ?? true))
+                    {
+                        IImageSourceHandler imageSourceHandler = null;
+                        if (_materialButton.ImageSource is UriImageSource)
+                        {
+                            imageSourceHandler = new ImageLoaderSourceHandler();
+                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
+                        }
+                        else if(_materialButton.ImageSource is FileImageSource)
+                        {
+                            imageSourceHandler = new FileImageSourceHandler();
+                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
+                        }
+                        else if (_materialButton.ImageSource is StreamImageSource)
+                        {
+                            imageSourceHandler = new StreamImagesourceHandler();
+                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
+                        }
+                        else if(_materialButton.ImageSource is FontImageSource)
+                        {
+                            imageSourceHandler = new FontImageSourceHandler();
+                            image = imageSourceHandler.LoadImageAsync(_materialButton.ImageSource).Result;
+                        }
+                    }
                     UIGraphics.BeginImageContextWithOptions(new CGSize(18, 18), false, 0f);
                     image?.Draw(new CGRect(0, 0, 18, 18));
 

--- a/XF.Material/Platforms/Uap/ImageSourceExtensions.cs
+++ b/XF.Material/Platforms/Uap/ImageSourceExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+
+namespace XF.Material.Uwp
+{
+    public static class ImageSourceExtensions
+    {
+        public static IImageSourceHandler GetImageSourceHandler(this ImageSource source)
+        {
+            return source switch
+            {
+                FileImageSource _ => new FileImageSourceHandler(),
+                StreamImageSource _ => new StreamImagesourceHandler(),
+                FontImageSource _ => new FontImageSourceHandler(),
+                _ => new ImageLoaderSourceHandler(),
+            };
+        }
+    }
+}

--- a/XF.Material/UI/Dialogs/Internals/ActionModel.cs
+++ b/XF.Material/UI/Dialogs/Internals/ActionModel.cs
@@ -14,7 +14,7 @@ namespace XF.Material.Forms.UI.Dialogs.Internals
 
         public bool IsSelected { get; set; }
 
-        public string Image { get; set; }
+        public ImageSource Image { get; set; }
 
         public string Text { get; set; }
 

--- a/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml.cs
+++ b/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml.cs
@@ -176,7 +176,7 @@ namespace XF.Material.Forms.UI.Dialogs
         {
             var width = Convert.ToDouble(param["width"]);
             var index = Convert.ToInt32(param["parameter"]);
-            var maxWidth = string.IsNullOrEmpty(_choices[index].Image) ? width : width + 40;
+            var maxWidth = (_choices[index].Image?.IsEmpty ?? true) ? width : width + 40;
             _itemChecker++;
 
             if (_maxWidth < maxWidth)

--- a/XF.Material/UI/MaterialIconButton.xaml.cs
+++ b/XF.Material/UI/MaterialIconButton.xaml.cs
@@ -30,7 +30,7 @@ namespace XF.Material.Forms.UI
 
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(MaterialElevation), typeof(MaterialIconButton), new MaterialElevation(2, 8));
 
-        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(string), typeof(MaterialIconButton));
+        public static readonly BindableProperty ImageProperty = BindableProperty.Create(nameof(Image), typeof(ImageSource), typeof(MaterialIconButton));
 
         public static readonly BindableProperty PressedBackgroundColorProperty = BindableProperty.Create(nameof(PressedBackgroundColor), typeof(Color), typeof(MaterialIconButton), default(Color));
 
@@ -115,9 +115,9 @@ namespace XF.Material.Forms.UI
             set => SetValue(ElevationProperty, value);
         }
 
-        public string Image
+        public ImageSource Image
         {
-            get => (string)GetValue(ImageProperty);
+            get => (ImageSource)GetValue(ImageProperty);
             set => SetValue(ImageProperty, value);
         }
 
@@ -202,7 +202,7 @@ namespace XF.Material.Forms.UI
             _button.Elevation = elevation;
         }
 
-        private void OnImageChanged(string image)
+        private void OnImageChanged(ImageSource image)
         {
             _icon.Source = image;
         }

--- a/XF.Material/XF.Material.csproj
+++ b/XF.Material/XF.Material.csproj
@@ -117,6 +117,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Platforms\Uap\ImageSourceExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.3" />
     <PackageReference Include="Xamarin.Essentials" Version="1.5.3.2" />
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.530" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Right now you can only load images from files.
### :new: What is the new behavior (if this is a feature change)?
Now you can supply font images, images from URL and your own stream of images rather than using only files.
### :boom: Does this PR introduce a breaking change?
No.
### :bug: Recommendations for testing

I checked for the FontImageSource in MaterialMenuButton and it works. Same for MenuItem. I am assuming other sources works too. However if you want to test other sources left untested are: Stream, URL loading and File loading.

However, I couldn't test MaterialButton ImageSource for iPhone. Also Dialog's image property for both iPhones and Android.
This edit hasn't changed anything for Android - it still seems that XF under-the-hood is using Image property even if you set ImageSource(?). That seemed odd to me.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/XF-Material-Library/issues/339
### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [?] Relevant documentation was updated
- [X] Rebased onto current develop
