### PR TITLE
Remove binding and icon tinting

### DIFF
--- a/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml
+++ b/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml
@@ -42,7 +42,6 @@
                                 <material:MaterialIcon x:Name="Icon"
                                                        HeightRequest="24"
                                                        Source="{Binding Image}"
-                                                       TintColor="{Binding Source={x:Reference Label}, Path=TextColor}"
                                                        VerticalOptions="Center"
                                                        WidthRequest="24">
                                     <View.Triggers>
@@ -54,7 +53,6 @@
                                 <internal:MenuDialogLabel x:Name="Label"
                                                           Grid.Column="1"
                                                           local:MaterialMenuDialog.Parameter="{Binding Index}"
-                                                          HeightRequest="{Binding Source={x:Reference DialogActionList}, Path=RowHeight}"
                                                           HorizontalOptions="StartAndExpand"
                                                           LineBreakMode="TailTruncation"
                                                           LineHeight="0"


### PR DESCRIPTION


### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

(Two) bug fix(es)

### :arrow_heading_down: What is the current behavior?

Before it was tinting the Icon by label color and hogging performance with leftover binding.

### :new: What is the new behavior (if this is a feature change)?

Removed tint for icon and removed binding.

### :boom: Does this PR introduce a breaking change?

Kind a.

### :memo: Links to relevant issues/docs

#345 
#344 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [?] Relevant documentation was updated
- [x] Rebased onto current develop
