### PR TITLE
[fix #351] fix MaterialDateField always displaying a margin at its bottom

### DIFF
--- a/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
@@ -2,10 +2,10 @@
 <ContentPage
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:MaterialMvvmSample.Views"
     xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
     x:Class="MaterialMvvmSample.Views.MaterialTextFieldView">
-    <ContentPage.Content>
+    
+    <ScrollView>
         <StackLayout Orientation="Vertical"
                      Padding="20">
             <material:MaterialTextField Placeholder="Auto Capitalization"
@@ -24,7 +24,14 @@
             <material:MaterialTextField Placeholder="Choices"
                                         InputType="Choice"
                                         Choices="{Binding Choices}"/>
+            <material:MaterialDateField Placeholder="Date" />
+            <material:MaterialDateField Placeholder="Date and tips"
+                                        HelperText="Your birthday"
+                                        />
+            <material:MaterialDateField Placeholder="Error"
+                                        ErrorText="some error"
+                                        HasError="True" />
 
         </StackLayout>
-    </ContentPage.Content>
+    </ScrollView>
 </ContentPage>

--- a/XF.Material/UI/MaterialDateField.xaml
+++ b/XF.Material/UI/MaterialDateField.xaml
@@ -8,10 +8,10 @@
         <TapGestureRecognizer x:Name="mainTapGesture"
                               NumberOfTapsRequired="1" />
     </View.GestureRecognizers>
-    <ContentView.Content>
-        <Grid x:Name="_gridContainer"
-              ColumnSpacing="0"
-              RowSpacing="0">
+
+    <Grid x:Name="_gridContainer"
+          ColumnSpacing="0"
+          RowSpacing="0">
             <View.GestureRecognizers>
                 <TapGestureRecognizer x:Name="tapGesture"
                                       NumberOfTapsRequired="1" />
@@ -19,7 +19,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition x:Name="_autoSizingRow"
                                Height="56" />
-                <RowDefinition Height="20" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -120,6 +120,7 @@
                                    WidthRequest="24" />
             
             <material:MaterialLabel x:Name="helper"
+                                    HeightRequest="20"
                                     Grid.Row="1"
                                     Grid.Column="0"
                                     Grid.ColumnSpan="3"
@@ -141,6 +142,7 @@
                 </Label.Triggers>
             </material:MaterialLabel>
             <material:MaterialLabel x:Name="counter"
+                                    HeightRequest="20"
                                     Grid.Row="1"
                                     Grid.Column="2"
                                     Margin="0,4,12,0"
@@ -157,5 +159,5 @@
                 </Label.Triggers>
             </material:MaterialLabel>
         </Grid>
-    </ContentView.Content>
+
 </ContentView>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix #351 

### :arrow_heading_down: What is the current behavior?
A MaterialDateField always display a blank area below itself, reserved for its helper text, even if it is empty/null.

### :new: What is the new behavior (if this is a feature change)?
A MaterialDateField now display the area below itself only if its helper text is set.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Test project updated

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
