### PR TITLE
rewrite materialdatepicker so it works correctly, especially on iOS

### DIFF
--- a/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
+++ b/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Core\PlatformContainer.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="Renderers\MaterialDatePickerRenderer.cs" />
     <Compile Include="Renderers\MViewCellRenderer.cs" />
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />

--- a/Samples/MaterialMvvmSample.iOS/Renderers/MaterialDatePickerRenderer.cs
+++ b/Samples/MaterialMvvmSample.iOS/Renderers/MaterialDatePickerRenderer.cs
@@ -1,0 +1,33 @@
+﻿using MaterialMvvmSample.iOS.Renderers;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+using XF.Material.Forms.UI.Internals;
+
+[assembly:ExportRenderer(typeof(MaterialDatePicker), typeof(MaterialDatePickerRenderer))]
+
+namespace MaterialMvvmSample.iOS.Renderers
+{
+    /// <summary>
+    /// Remove border
+    /// </summary>
+    public class MaterialDatePickerRenderer : DatePickerRenderer
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<DatePicker> e)
+        {
+            base.OnElementChanged(e);
+            if (e.NewElement != null)
+            {
+                Control.Layer.BorderWidth = 0;
+                Control.BorderStyle = UITextBorderStyle.None;
+            }
+        }
+
+        protected override UITextField CreateNativeControl()
+        {
+            var control = base.CreateNativeControl();
+            control.BorderStyle = UITextBorderStyle.None;
+            return control;
+        }
+    }
+}

--- a/XF.Material/UI/MaterialDateField.xaml
+++ b/XF.Material/UI/MaterialDateField.xaml
@@ -3,22 +3,15 @@
              xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:internal="clr-namespace:XF.Material.Forms.UI.Internals"
-             xmlns:material="clr-namespace:XF.Material.Forms.UI">
-    <View.GestureRecognizers>
-        <TapGestureRecognizer x:Name="mainTapGesture"
-                              NumberOfTapsRequired="1" />
-    </View.GestureRecognizers>
-
-    <Grid x:Name="_gridContainer"
-          ColumnSpacing="0"
-          RowSpacing="0">
-            <View.GestureRecognizers>
-                <TapGestureRecognizer x:Name="tapGesture"
-                                      NumberOfTapsRequired="1" />
-            </View.GestureRecognizers>
+             xmlns:material="clr-namespace:XF.Material.Forms.UI"
+             x:Name="ThisControl">
+    <ContentView.GestureRecognizers>
+        <TapGestureRecognizer NumberOfTapsRequired="1" Tapped="OnTap" />
+    </ContentView.GestureRecognizers>
+    
+        <Grid ColumnSpacing="0" RowSpacing="0">
             <Grid.RowDefinitions>
-                <RowDefinition x:Name="_autoSizingRow"
-                               Height="56" />
+                <RowDefinition x:Name="_autoSizingRow" Height="54" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
@@ -30,15 +23,15 @@
             <BoxView x:Name="backgroundCard"
                      Grid.Row="0"
                      Grid.ColumnSpan="4"
-                     BackgroundColor="#DCDCDC"
+                     BackgroundColor="{Binding BackgroundColor,Source={x:Reference ThisControl}}"
                      CornerRadius="4,4,0,0" />
             <material:MaterialIcon x:Name="leadingIcon"
-                                   Grid.Row="0"
-                                   Grid.Column="0"
                                    Margin="12,16,0,16"
                                    HeightRequest="24"
                                    VerticalOptions="Start"
-                                   WidthRequest="24">
+                                   WidthRequest="24"
+                                   TintColor="{Binding LeadingIconTintColor,Source={x:Reference ThisControl}}"
+                                   Source="{Binding LeadingIcon,Source={x:Reference ThisControl}}">
                 <View.Triggers>
                     <Trigger TargetType="material:MaterialIcon" Property="Source" Value="{x:Null}">
                         <Setter Property="IsVisible" Value="False" />
@@ -49,44 +42,42 @@
                                     Grid.Row="0"
                                     Grid.Column="1"
                                     Margin="12,0,12,0"
-                                    FontSize="{Binding Source={x:Reference datePicker}, Path=FontSize}"
+                                    FontSize="{Binding TextFontSize,Source={x:Reference ThisControl}}"
+                                    FontFamily="{Binding PlaceholderFontFamily,Source={x:Reference ThisControl}}"
                                     InputTransparent="True"
-                                    Text="Placeholder"
-                                    TextColor="#99000000"
+                                    Text="{Binding Placeholder,Source={x:Reference ThisControl}}"
+                                    TextColor="{Binding PlaceholderColor,Source={x:Reference ThisControl}}"
                                     TypeScale="Body2"
                                     VerticalOptions="Center"
                                     VerticalTextAlignment="Center" />
-            <ContentView x:Name="_inputContainer"
-                         Grid.Row="0"
-                         Grid.Column="1"
-                         Grid.ColumnSpan="2"
-                         HorizontalOptions="FillAndExpand"
-                         VerticalOptions="Start">
-                
-                <internal:MaterialDatePicker x:Name="datePicker"
-                                        Margin="12,24,12,0"
-                                        FontFamily="{DynamicResource Material.FontFamily.Body2}"
-                                        FontSize="16"
-                                        HorizontalOptions="FillAndExpand"
-                                        TextColor="#D0000000"                                             
-                                        VerticalOptions="FillAndExpand" />
-                
-                <ContentView.Triggers>
+
+            <internal:MaterialDatePicker x:Name="datePicker" IgnoreCancel="False"
+                Grid.Column="1" Grid.ColumnSpan="2" 
+                Margin="12,28,12,0"
+                FontFamily="{Binding TextFontFamily,Source={x:Reference ThisControl}}"
+                FontSize="{Binding TextFontSize,Source={x:Reference ThisControl}}"
+                HorizontalOptions="FillAndExpand"
+                TextColor="{Binding TextColor,Source={x:Reference ThisControl}}"
+                VerticalOptions="Start"
+                TintColor="{Binding TintColor,Source={x:Reference ThisControl}}"
+                BackgroundColor="Transparent">
+                <internal:MaterialDatePicker.Triggers>
                     <DataTrigger Binding="{Binding Source={x:Reference trailingIcon}, Path=IsVisible}"
-                                 TargetType="ContentView"
+                                 TargetType="internal:MaterialDatePicker"
                                  Value="True">
                         <Setter Property="Grid.ColumnSpan" Value="1" />
                     </DataTrigger>
-                </ContentView.Triggers>
-            </ContentView>
+                </internal:MaterialDatePicker.Triggers>
+            </internal:MaterialDatePicker>
             
-            <BoxView x:Name="persistentUnderline"
+            <!-- persistentUnderline -->
+            <BoxView
                      Grid.Row="0"
                      Grid.ColumnSpan="4"
                      Margin="0,0,0,-1"
                      HeightRequest="1"
                      HorizontalOptions="FillAndExpand"
-                     IsVisible="False"
+                     IsVisible="{Binding AlwaysShowUnderline,Source={x:Reference ThisControl}}"
                      VerticalOptions="End"
                      Color="{Binding Source={x:Reference underline}, Path=Color}" />
             
@@ -105,9 +96,14 @@
                                    Margin="0,16,12,16"
                                    HeightRequest="24"
                                    IsVisible="False"
-                                   Source="xf_clear"
+                                   Source="{Binding ClearIcon,Source={x:Reference ThisControl}}"
+                                   TintColor="{Binding TextColor,Source={x:Reference ThisControl}}"
                                    VerticalOptions="Start"
-                                   WidthRequest="24" />
+                                   WidthRequest="24">
+                <material:MaterialIcon.GestureRecognizers>
+                    <TapGestureRecognizer Tapped="OnClear" />
+                </material:MaterialIcon.GestureRecognizers>
+            </material:MaterialIcon>
 
             <material:MaterialIcon x:Name="trailingIcon"
                                    Grid.Row="0"
@@ -115,6 +111,7 @@
                                    Margin="0,16,12,16"
                                    HeightRequest="24"
                                    IsVisible="False"
+                                   TintColor="{Binding TintColor,Source={x:Reference ThisControl}}"
                                    Source="xf_arrow_dropdown"
                                    VerticalOptions="Start"
                                    WidthRequest="24" />
@@ -125,8 +122,10 @@
                                     Grid.Column="0"
                                     Grid.ColumnSpan="3"
                                     Margin="12,4,12,0"
-                                    TextColor="#99000000"
-                                    TypeScale="Caption">
+                                    TextColor="{Binding HelperTextColor,Source={x:Reference ThisControl}}"
+                                    TypeScale="Caption"
+                                    Text="{Binding SmallText,Source={x:Reference ThisControl}}"
+                                    FontFamily="{Binding HelperTextFontFamily,Source={x:Reference ThisControl}}">
                 <Label.Triggers>
                     <Trigger TargetType="Label" Property="Text" Value="">
                         <Setter Property="IsVisible" Value="False" />
@@ -147,7 +146,8 @@
                                     Grid.Column="2"
                                     Margin="0,4,12,0"
                                     HorizontalOptions="End"
-                                    TextColor="#99000000"
+                                    TextColor="{Binding HelperTextColor,Source={x:Reference ThisControl}}"
+                                    FontFamily="{Binding HelperTextFontFamily,Source={x:Reference ThisControl}}"
                                     TypeScale="Caption">
                 <Label.Triggers>
                     <Trigger TargetType="Label" Property="Text" Value="">

--- a/XF.Material/UI/MaterialDateField.xaml.cs
+++ b/XF.Material/UI/MaterialDateField.xaml.cs
@@ -3,15 +3,18 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
+using XF.Material.Forms;
 using XF.Material.Forms.Resources;
+using XF.Material.Forms.UI;
 using XF.Material.Forms.UI.Internals;
 
 namespace XF.Material.Forms.UI
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="ContentView" />
     /// <summary>
     /// A control that let users enter and edit text.
     /// </summary>
@@ -19,67 +22,39 @@ namespace XF.Material.Forms.UI
     public partial class MaterialDateField : ContentView, IMaterialElementConfiguration
     {
         public static readonly BindableProperty AlwaysShowUnderlineProperty = BindableProperty.Create(nameof(AlwaysShowUnderline), typeof(bool), typeof(MaterialDateField), false);
-
-        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#DCDCDC"));
-
         public static readonly BindableProperty ErrorColorProperty = BindableProperty.Create(nameof(ErrorColor), typeof(Color), typeof(MaterialDateField), Material.Color.Error);
-
         public static readonly BindableProperty ErrorTextProperty = BindableProperty.Create(nameof(ErrorText), typeof(string), typeof(MaterialDateField));
-
         public static readonly BindableProperty FloatingPlaceholderColorProperty = BindableProperty.Create(nameof(FloatingPlaceholderColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
-
         public static readonly BindableProperty FloatingPlaceholderEnabledProperty = BindableProperty.Create(nameof(FloatingPlaceholderEnabled), typeof(bool), typeof(MaterialDateField), true);
-
         public static readonly BindableProperty FloatingPlaceholderFontSizeProperty = BindableProperty.Create(nameof(FloatingPlaceholderFontSize), typeof(double), typeof(MaterialDateField), 0d);
-
         public static readonly BindableProperty FocusCommandProperty = BindableProperty.Create(nameof(FocusCommand), typeof(Command<bool>), typeof(MaterialDateField));
-
         public static readonly BindableProperty HasErrorProperty = BindableProperty.Create(nameof(HasError), typeof(bool), typeof(MaterialDateField), false);
-
         public static readonly BindableProperty HelperTextColorProperty = BindableProperty.Create(nameof(HelperTextColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
-
         public static readonly BindableProperty HelperTextFontFamilyProperty = BindableProperty.Create(nameof(HelperTextFontFamily), typeof(string), typeof(MaterialDateField));
-
         public static readonly BindableProperty HelperTextProperty = BindableProperty.Create(nameof(HelperText), typeof(string), typeof(MaterialDateField), string.Empty);
-
         public static readonly BindableProperty HorizontalPaddingProperty = BindableProperty.Create(nameof(HorizontalPadding), typeof(MaterialHorizontalThickness), typeof(MaterialDateField), new MaterialHorizontalThickness(12d), defaultBindingMode: BindingMode.OneTime);
-
         public static readonly BindableProperty LeadingIconProperty = BindableProperty.Create(nameof(LeadingIcon), typeof(string), typeof(MaterialDateField));
-
         public static readonly BindableProperty LeadingIconTintColorProperty = BindableProperty.Create(nameof(LeadingIconTintColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
-
         public static readonly BindableProperty PlaceholderColorProperty = BindableProperty.Create(nameof(PlaceholderColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
-
         public static readonly BindableProperty PlaceholderFontFamilyProperty = BindableProperty.Create(nameof(PlaceholderFontFamily), typeof(string), typeof(MaterialDateField));
-
         public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(MaterialDateField), string.Empty);
-
         public static readonly BindableProperty ShouldAnimateUnderlineProperty = BindableProperty.Create(nameof(ShouldAnimateUnderline), typeof(bool), typeof(MaterialDateField), true);
-
         public static readonly BindableProperty DateChangeCommandProperty = BindableProperty.Create(nameof(DateChangeCommand), typeof(Command<DateTime?>), typeof(MaterialDateField));
-
         public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#D0000000"));
-
         public static readonly BindableProperty TextFontFamilyProperty = BindableProperty.Create(nameof(TextFontFamily), typeof(string), typeof(MaterialDateField));
-
         public static readonly BindableProperty TextFontSizeProperty = BindableProperty.Create(nameof(TextFontSize), typeof(double), typeof(MaterialDateField), 16d);
-
         public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime?), typeof(MaterialDateField), null, BindingMode.TwoWay);
-
         public static readonly BindableProperty TintColorProperty = BindableProperty.Create(nameof(TintColor), typeof(Color), typeof(MaterialDateField), Material.Color.Secondary);
-
         public static readonly BindableProperty ClearIconProperty = BindableProperty.Create(nameof(ClearIcon), typeof(string), typeof(MaterialDateField), "xf_clear");
-
         public static readonly BindableProperty UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
+        public new static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#DCDCDC"));
 
-        private const double AnimationDuration = 0.35;
         private readonly Easing _animationCurve = Easing.SinOut;
         private readonly Dictionary<string, Action> _propertyChangeActions;
-        private readonly IList<string> _choices;
-        private readonly bool _counterEnabled;
         private DisplayInfo _lastDeviceDisplay;
-        private readonly int _selectedIndex = -1;
-        private bool _wasFocused;
+        const uint AnimDurationMs = 350; //250/2;
+        const double AnimDurationS = AnimDurationMs/1000.0;
+        private bool? IsFloating = null;
 
         /// <summary>
         /// Initializes a new instance of <see cref="MaterialDateField"/>.
@@ -87,20 +62,26 @@ namespace XF.Material.Forms.UI
         public MaterialDateField()
         {
             InitializeComponent();
-            SetPropertyChangeHandler(ref _propertyChangeActions);
-            SetControl();
 
-            datePicker.PropertyChanged += DatePicker_PropertyChanged;
+            _propertyChangeActions = new Dictionary<string, Action>
+            {
+                { nameof(HelperText), () => OnHelperTextChanged() },
+                { nameof(ErrorText), () => OnErrorTextChanged() },
+
+                { nameof(Date), () => OnDateChanged(Date) },
+                { nameof(IsEnabled), () => OnEnabledChanged(IsEnabled) },
+                { nameof(HasError), () => UpdateErrorState() },
+                { nameof(FloatingPlaceholderEnabled), () => OnFloatingPlaceholderEnabledChanged() },
+            };
+
             datePicker.DateSelected += DatePicker_DateChanged;
-            datePicker.SizeChanged += Entry_SizeChanged;
+            //datePicker.SizeChanged += Entry_SizeChanged;
             datePicker.Focused += DatePicker_Focused;
             datePicker.Unfocused += DatePicker_Unfocused;
 
-            DeviceDisplay.MainDisplayInfoChanged += DeviceDisplay_MainDisplayInfoChanged;
             _lastDeviceDisplay = DeviceDisplay.MainDisplayInfo;
+            DeviceDisplay.MainDisplayInfoChanged += DeviceDisplay_MainDisplayInfoChanged;
         }
-
-        public event EventHandler<SelectedItemChangedEventArgs> ChoiceSelected;
 
         /// <summary>
         /// Raised when this text field receives focus.
@@ -118,24 +99,12 @@ namespace XF.Material.Forms.UI
         public event EventHandler<NullableDateChangedEventArgs> DateChanged;
 
         /// <summary>
-        /// Raised when the user finalizes the input on this text field using the return key.
-        /// </summary>
-        public event EventHandler Completed;
-
-        /// <summary>
         /// Gets or sets whether the underline accent of this text field should always show or not.
         /// </summary>
         public bool AlwaysShowUnderline
         {
-            get
-            {
-                return (bool)GetValue(AlwaysShowUnderlineProperty);
-            }
-
-            set
-            {
-                SetValue(AlwaysShowUnderlineProperty, value);
-            }
+            get => (bool)GetValue(AlwaysShowUnderlineProperty);
+            set => SetValue(AlwaysShowUnderlineProperty, value);
         }
 
         /// <summary>
@@ -143,28 +112,14 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public new Color BackgroundColor
         {
-            get
-            {
-                return (Color)GetValue(BackgroundColorProperty);
-            }
-
-            set
-            {
-                SetValue(BackgroundColorProperty, value);
-            }
+            get => (Color)GetValue(BackgroundColorProperty);
+            set => SetValue(BackgroundColorProperty, value);
         }
 
         public ImageSource ClearIcon
         {
-            get
-            {
-                return (string)GetValue(ClearIconProperty);
-            }
-
-            set
-            {
-                SetValue(ClearIconProperty, value);
-            }
+            get => (string)GetValue(ClearIconProperty);
+            set => SetValue(ClearIconProperty, value);
         }
 
         /// <summary>
@@ -173,15 +128,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color ErrorColor
         {
-            get
-            {
-                return (Color)GetValue(ErrorColorProperty);
-            }
-
-            set
-            {
-                SetValue(ErrorColorProperty, value);
-            }
+            get => (Color)GetValue(ErrorColorProperty);
+            set => SetValue(ErrorColorProperty, value);
         }
 
         /// <summary>
@@ -189,15 +137,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string ErrorText
         {
-            get
-            {
-                return (string)GetValue(ErrorTextProperty);
-            }
-
-            set
-            {
-                SetValue(ErrorTextProperty, value);
-            }
+            get => (string)GetValue(ErrorTextProperty);
+            set => SetValue(ErrorTextProperty, value);
         }
 
         /// <summary>
@@ -205,15 +146,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color FloatingPlaceholderColor
         {
-            get
-            {
-                return (Color)GetValue(FloatingPlaceholderColorProperty);
-            }
-
-            set
-            {
-                SetValue(FloatingPlaceholderColorProperty, value);
-            }
+            get => (Color)GetValue(FloatingPlaceholderColorProperty);
+            set => SetValue(FloatingPlaceholderColorProperty, value);
         }
 
         /// <summary>
@@ -221,15 +155,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public bool FloatingPlaceholderEnabled
         {
-            get
-            {
-                return (bool)GetValue(FloatingPlaceholderEnabledProperty);
-            }
-
-            set
-            {
-                SetValue(FloatingPlaceholderEnabledProperty, value);
-            }
+            get => (bool)GetValue(FloatingPlaceholderEnabledProperty);
+            set => SetValue(FloatingPlaceholderEnabledProperty, value);
         }
 
         /// <summary>
@@ -237,15 +164,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public double FloatingPlaceholderFontSize
         {
-            get
-            {
-                return (double)GetValue(FloatingPlaceholderFontSizeProperty);
-            }
-
-            set
-            {
-                SetValue(FloatingPlaceholderFontSizeProperty, value);
-            }
+            get => (double)GetValue(FloatingPlaceholderFontSizeProperty);
+            set => SetValue(FloatingPlaceholderFontSizeProperty, value);
         }
 
         /// <summary>
@@ -253,15 +173,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Command<bool> FocusCommand
         {
-            get
-            {
-                return (Command<bool>)GetValue(FocusCommandProperty);
-            }
-
-            set
-            {
-                SetValue(FocusCommandProperty, value);
-            }
+            get => (Command<bool>)GetValue(FocusCommandProperty);
+            set => SetValue(FocusCommandProperty, value);
         }
 
         /// <summary>
@@ -269,15 +182,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public bool HasError
         {
-            get
-            {
-                return (bool)GetValue(HasErrorProperty);
-            }
-
-            set
-            {
-                SetValue(HasErrorProperty, value);
-            }
+            get => (bool)GetValue(HasErrorProperty);
+            set => SetValue(HasErrorProperty, value);
         }
 
         /// <summary>
@@ -285,15 +191,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string HelperText
         {
-            get
-            {
-                return (string)GetValue(HelperTextProperty);
-            }
-
-            set
-            {
-                SetValue(HelperTextProperty, value);
-            }
+            get => (string)GetValue(HelperTextProperty);
+            set => SetValue(HelperTextProperty, value);
         }
 
         /// <summary>
@@ -301,15 +200,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color HelperTextColor
         {
-            get
-            {
-                return (Color)GetValue(HelperTextColorProperty);
-            }
-
-            set
-            {
-                SetValue(HelperTextColorProperty, value);
-            }
+            get => (Color)GetValue(HelperTextColorProperty);
+            set => SetValue(HelperTextColorProperty, value);
         }
 
         /// <summary>
@@ -317,15 +209,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string HelperTextFontFamily
         {
-            get
-            {
-                return (string)GetValue(HelperTextFontFamilyProperty);
-            }
-
-            set
-            {
-                SetValue(HelperTextFontFamilyProperty, value);
-            }
+            get => (string)GetValue(HelperTextFontFamilyProperty);
+            set => SetValue(HelperTextFontFamilyProperty, value);
         }
 
         /// <summary>
@@ -333,15 +218,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public MaterialHorizontalThickness HorizontalPadding
         {
-            get
-            {
-                return (MaterialHorizontalThickness)GetValue(HorizontalPaddingProperty);
-            }
-
-            set
-            {
-                SetValue(HorizontalPaddingProperty, value);
-            }
+            get => (MaterialHorizontalThickness)GetValue(HorizontalPaddingProperty);
+            set => SetValue(HorizontalPaddingProperty, value);
         }
 
         /// <summary>
@@ -349,15 +227,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string LeadingIcon
         {
-            get
-            {
-                return (string)GetValue(LeadingIconProperty);
-            }
-
-            set
-            {
-                SetValue(LeadingIconProperty, value);
-            }
+            get => (string)GetValue(LeadingIconProperty);
+            set => SetValue(LeadingIconProperty, value);
         }
 
         /// <summary>
@@ -365,15 +236,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color LeadingIconTintColor
         {
-            get
-            {
-                return (Color)GetValue(LeadingIconTintColorProperty);
-            }
-
-            set
-            {
-                SetValue(LeadingIconTintColorProperty, value);
-            }
+            get => (Color)GetValue(LeadingIconTintColorProperty);
+            set => SetValue(LeadingIconTintColorProperty, value);
         }
 
         /// <summary>
@@ -381,17 +245,12 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string Placeholder
         {
-            get
-            {
-                return (string)GetValue(PlaceholderProperty);
-            }
+            get => (string)GetValue(PlaceholderProperty);
 
             set
             {
-                if (string.IsNullOrWhiteSpace(value))
-                {
-                    throw new ArgumentNullException($"{nameof(Placeholder)} must not be null, empty, or a white space.");
-                }
+                if (string.IsNullOrEmpty(value))
+                    throw new ArgumentNullException($"{nameof(Placeholder)} must not be null or empty");
 
                 SetValue(PlaceholderProperty, value);
             }
@@ -402,15 +261,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color PlaceholderColor
         {
-            get
-            {
-                return (Color)GetValue(PlaceholderColorProperty);
-            }
-
-            set
-            {
-                SetValue(PlaceholderColorProperty, value);
-            }
+            get => (Color)GetValue(PlaceholderColorProperty);
+            set => SetValue(PlaceholderColorProperty, value);
         }
 
         /// <summary>
@@ -418,15 +270,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string PlaceholderFontFamily
         {
-            get
-            {
-                return (string)GetValue(PlaceholderFontFamilyProperty);
-            }
-
-            set
-            {
-                SetValue(PlaceholderFontFamilyProperty, value);
-            }
+            get => (string)GetValue(PlaceholderFontFamilyProperty);
+            set => SetValue(PlaceholderFontFamilyProperty, value);
         }
 
         /// <summary>
@@ -434,15 +279,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public bool ShouldAnimateUnderline
         {
-            get
-            {
-                return (bool)GetValue(ShouldAnimateUnderlineProperty);
-            }
-
-            set
-            {
-                SetValue(ShouldAnimateUnderlineProperty, value);
-            }
+            get => (bool)GetValue(ShouldAnimateUnderlineProperty);
+            set => SetValue(ShouldAnimateUnderlineProperty, value);
         }
 
         /// <summary>
@@ -450,21 +288,14 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public DateTime? Date
         {
-            get
-            {
-                return (DateTime?)GetValue(DateProperty);
-            }
+            get => (DateTime?)GetValue(DateProperty);
 
             set
             {
                 if (value.HasValue && !FloatingPlaceholderEnabled)
-                {
                     placeholder.IsVisible = false;
-                }
                 else if (!value.HasValue && !FloatingPlaceholderEnabled)
-                {
                     placeholder.IsVisible = true;
-                }
 
                 SetValue(DateProperty, value);
             }
@@ -475,15 +306,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Command<DateTime?> DateChangeCommand
         {
-            get
-            {
-                return (Command<DateTime?>)GetValue(DateChangeCommandProperty);
-            }
-
-            set
-            {
-                SetValue(DateChangeCommandProperty, value);
-            }
+            get => (Command<DateTime?>)GetValue(DateChangeCommandProperty);
+            set => SetValue(DateChangeCommandProperty, value);
         }
 
         /// <summary>
@@ -491,15 +315,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color TextColor
         {
-            get
-            {
-                return (Color)GetValue(TextColorProperty);
-            }
-
-            set
-            {
-                SetValue(TextColorProperty, value);
-            }
+            get => (Color)GetValue(TextColorProperty);
+            set => SetValue(TextColorProperty, value);
         }
 
         /// <summary>
@@ -507,15 +324,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public string TextFontFamily
         {
-            get
-            {
-                return (string)GetValue(TextFontFamilyProperty);
-            }
-
-            set
-            {
-                SetValue(TextFontFamilyProperty, value);
-            }
+            get => (string)GetValue(TextFontFamilyProperty);
+            set => SetValue(TextFontFamilyProperty, value);
         }
 
         /// <summary>
@@ -523,15 +333,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public double TextFontSize
         {
-            get
-            {
-                return (double)GetValue(TextFontSizeProperty);
-            }
-
-            set
-            {
-                SetValue(TextFontSizeProperty, value);
-            }
+            get => (double)GetValue(TextFontSizeProperty);
+            set => SetValue(TextFontSizeProperty, value);
         }
 
         /// <summary>
@@ -540,15 +343,8 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color TintColor
         {
-            get
-            {
-                return (Color)GetValue(TintColorProperty);
-            }
-
-            set
-            {
-                SetValue(TintColorProperty, value);
-            }
+            get => (Color)GetValue(TintColorProperty);
+            set => SetValue(TintColorProperty, value);
         }
 
         /// <summary>
@@ -556,54 +352,42 @@ namespace XF.Material.Forms.UI
         /// </summary>
         public Color UnderlineColor
         {
-            get
-            {
-                return (Color)GetValue(UnderlineColorProperty);
-            }
-
-            set
-            {
-                SetValue(UnderlineColorProperty, value);
-            }
+            get => (Color)GetValue(UnderlineColorProperty);
+            set => SetValue(UnderlineColorProperty, value);
         }
 
-        /// <inheritdoc />
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
+        public string SmallText => HasError ? ErrorText : HelperText;
+        public bool IsHelperVisible => IsEnabled && !string.IsNullOrEmpty(HelperText);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void ElementChanged(bool created)
+        void IMaterialElementConfiguration.ElementChanged(bool created)
         {
         }
 
         /// <summary>
-        /// Requests to set focus on this text field.
+        /// Requests to set focus on this field.
         /// </summary>
         public new void Focus()
-        {
-            datePicker.Focus();
-        }
+            => datePicker.Focus();
 
         /// <summary>
-        /// Requests to unset the focus on this text field.
+        /// Requests to unset the focus on this field.
         /// </summary>
         public new void Unfocus()
-        {
-            datePicker.Unfocus();
-        }
+            => datePicker.Unfocus();
 
         protected override void OnBindingContextChanged()
         {
             base.OnBindingContextChanged();
-
-            AnimateToInactiveOrFocusedStateOnStart(BindingContext);
+            if(BindingContext != null)
+                Device.BeginInvokeOnMainThread(() => UpdateState(false));
         }
 
         protected override void OnParentSet()
         {
             base.OnParentSet();
-
-            AnimateToInactiveOrFocusedStateOnStart(Parent);
+            if(Parent != null)
+                Device.BeginInvokeOnMainThread(() => UpdateState(false));
         }
 
         /// <inheritdoc />
@@ -615,249 +399,97 @@ namespace XF.Material.Forms.UI
         {
             base.OnPropertyChanged(propertyName);
 
-            if (propertyName == null)
-            {
-                return;
-            }
-
-            if (_propertyChangeActions != null && _propertyChangeActions.TryGetValue(propertyName, out var handlePropertyChange))
-            {
+            if (propertyName != null && _propertyChangeActions != null && _propertyChangeActions.TryGetValue(propertyName, out var handlePropertyChange))
                 handlePropertyChange();
-            }
         }
 
-        private void AnimateToActivatedState()
+        /// <summary>
+        /// AnimateToInactiveOrFocusedState: !datePicker.NullableDate.HasValue
+        /// </summary>
+        private void UpdateState(bool animated = true)
         {
+            var isFocused = datePicker.IsFocused;
+            var isFloating = FloatingPlaceholderEnabled && (Date.HasValue || isFocused);
+            var tintColor = isFocused ? (HasError ? ErrorColor : TintColor) : (isFloating ? FloatingPlaceholderColor : PlaceholderColor);
+
+            UnderlineSetColorState();
             var anim = new Animation();
-            var hasDate = Date.HasValue;
 
-            if (datePicker.IsFocused)
+            if (isFloating != IsFloating)
             {
-                var tintColor = HasError ? ErrorColor : TintColor;
-
-                if (ShouldAnimateUnderline)
+                IsFloating = isFloating;
+                
+                if (FloatingPlaceholderEnabled)
                 {
-                    anim.Add(0.0, AnimationDuration, new Animation(v => underline.HeightRequest = v, 1, 2, _animationCurve, () =>
+                    var normalPlaceholderFontSize = datePicker.FontSize;
+                    var floatingPlaceholderFontSize = FloatingPlaceholderFontSize == 0 ? normalPlaceholderFontSize * 0.75 : FloatingPlaceholderFontSize;
+                    var startFont = isFloating ? normalPlaceholderFontSize : floatingPlaceholderFontSize;
+                    var endFOnt = isFloating ? floatingPlaceholderFontSize : normalPlaceholderFontSize;
+                    var startY = placeholder.TranslationY;
+                    var endY = isFloating ? -(normalPlaceholderFontSize * 0.8) : 0;
+
+                    anim.Add(0, AnimDurationS, new Animation(v => placeholder.FontSize = v, startFont, endFOnt, _animationCurve));
+                    anim.Add(0, AnimDurationS, new Animation(v => placeholder.TranslationY = v, startY, endY, _animationCurve, () =>
                     {
-                        underline.Color = tintColor;
+                        placeholder.TextColor = tintColor;
                     }));
                 }
-
-                placeholder.TextColor = tintColor;
+                else
+                {
+                    placeholder.TextColor = tintColor;
+                }
             }
             else
             {
-                var underlineColor = HasError ? ErrorColor : UnderlineColor;
-                var placeholderColor = HasError ? ErrorColor : FloatingPlaceholderColor;
-
-                var endHeight = hasDate ? 1 : 0;
-
-                if (ShouldAnimateUnderline)
-                {
-                    anim.Add(0.0, AnimationDuration, new Animation(v => underline.HeightRequest = v, underline.HeightRequest, endHeight, _animationCurve, () =>
-                    {
-                        underline.Color = underlineColor;
-                    }));
-                }
-
-                placeholder.TextColor = placeholderColor;
+                placeholder.TextColor = tintColor;
             }
 
-            anim.Commit(this, "UnfocusAnimation", rate: 2, length: (uint)(Device.RuntimePlatform == Device.iOS ? 500 : AnimationDuration * 1000), easing: _animationCurve);
+            UnderlineSetState(anim);
+
+            if(animated)
+                anim.Commit(this, Guid.NewGuid().ToString(), rate: 2, length: AnimDurationMs, easing: _animationCurve);
+            else
+                anim.Commit(this, Guid.NewGuid().ToString(), 1, 1);
         }
 
-        private void AnimateToInactiveOrFocusedState()
+        private async Task UpdateErrorState()
         {
-            Color tintColor;
-            var preferredStartFont = FloatingPlaceholderFontSize == 0 ? datePicker.FontSize * 0.75 : FloatingPlaceholderFontSize;
-            var preferredEndFont = FloatingPlaceholderFontSize == 0 ? datePicker.FontSize * 0.75 : FloatingPlaceholderFontSize;
-            var startFont = datePicker.IsFocused ? datePicker.FontSize : preferredStartFont;
-            var endFOnt = datePicker.IsFocused ? preferredEndFont : datePicker.FontSize;
-            var startY = placeholder.TranslationY;
-            var endY = datePicker.IsFocused ? -(datePicker.FontSize * 0.8) : 0;
+            var isFocused = datePicker.IsFocused;
+            var isFloating = FloatingPlaceholderEnabled && (Date.HasValue || isFocused);
+            var tintColor = isFocused ? (HasError ? ErrorColor : TintColor) : (isFloating ? FloatingPlaceholderColor : PlaceholderColor);
 
             if (HasError)
             {
-                tintColor = datePicker.IsFocused ? ErrorColor : PlaceholderColor;
-            }
-            else
-            {
-                tintColor = datePicker.IsFocused ? TintColor : PlaceholderColor;
-            }
+                trailingIcon.IsVisible = true;
+                trailingIcon.Source = "xf_error";
 
-            var anim = FloatingPlaceholderEnabled ? new Animation
-            {
+                placeholder.TextColor = tintColor;
+                counter.TextColor = ErrorColor;
+                UnderlineSetColorState();
+
+                if (string.IsNullOrEmpty(ErrorText))
                 {
-                    0.0,
-                    AnimationDuration,
-                    new Animation(v => placeholder.FontSize = v, startFont, endFOnt, _animationCurve)
-                },
-                {
-                    0.0,
-                    AnimationDuration,
-                    new Animation(v => placeholder.TranslationY = v, startY, endY, _animationCurve, () =>
-                    {
-                        if(HasError && datePicker.IsFocused)
-                        {
-                            placeholder.TextColor = ErrorColor;
-                        }
-
-                        placeholder.TextColor = tintColor;
-                    })
-                }
-            } : new Animation();
-
-            if (datePicker.IsFocused)
-            {
-                if (ShouldAnimateUnderline)
-                {
-                    underline.Color = HasError ? ErrorColor : TintColor;
-
-                    anim.Add(0.0, AnimationDuration, new Animation(v => underline.WidthRequest = v, 0, Width, _animationCurve, () =>
-                    {
-                        underline.WidthRequest = -1;
-                        underline.HorizontalOptions = LayoutOptions.FillAndExpand;
-                    }));
-                }
-            }
-            else
-            {
-                if (ShouldAnimateUnderline)
-                {
-                    anim.Add(0.0, AnimationDuration, new Animation(v => underline.HeightRequest = v, underline.HeightRequest, 0, _animationCurve, () =>
-                    {
-                        underline.WidthRequest = 0;
-                        underline.HeightRequest = 2;
-                        underline.HorizontalOptions = LayoutOptions.Center;
-                    }));
-                }
-            }
-
-            anim.Commit(this, "FocusAnimation", rate: 2, length: (uint)(Device.RuntimePlatform == Device.iOS ? 500 : AnimationDuration * 1000), easing: _animationCurve);
-        }
-
-        private void AnimateToInactiveOrFocusedStateOnStart(object startObject)
-        {
-            var placeholderEndY = -(datePicker.FontSize * 0.8);
-            var placeholderEndFont = datePicker.FontSize * 0.75;
-
-            if (!FloatingPlaceholderEnabled && !datePicker.NullableDate.HasValue)
-            {
-                placeholder.TextColor = PlaceholderColor;
-            }
-
-            if (startObject != null && Date.HasValue /*&& !this._wasFocused*/)
-            {
-                datePicker.Opacity = 0;
-
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    var anim = new Animation();
-
-                    if (FloatingPlaceholderEnabled)
-                    {
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, datePicker.FontSize, placeholderEndFont, _animationCurve));
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.TranslationY = v, placeholder.TranslationY, placeholderEndY, _animationCurve, () =>
-                        {
-                            placeholder.TextColor = HasError ? ErrorColor : FloatingPlaceholderColor;
-                            datePicker.Opacity = 1;
-                        }));
-                    }
-
-                    if (ShouldAnimateUnderline)
-                    {
-                        underline.Color = HasError ? ErrorColor : TintColor;
-                        underline.HeightRequest = 1;
-                        anim.Add(0.0, AnimationDuration, new Animation(v => underline.WidthRequest = v, 0, Width, _animationCurve, () => underline.HorizontalOptions = LayoutOptions.FillAndExpand));
-                    }
-
-                    anim.Commit(this, "Anim2", rate: 2, length: (uint)(AnimationDuration * 1000), easing: _animationCurve);
-                });
-
-                datePicker.Opacity = 1;
-
-                return;
-            }
-
-            if (startObject != null && !Date.HasValue && placeholder.TranslationY == placeholderEndY)
-            {
-                if (datePicker.IsFocused)
-                {
-                    return;
-                }
-
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    var anim = new Animation();
-
-                    if (FloatingPlaceholderEnabled)
-                    {
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.FontSize = v, placeholderEndFont, datePicker.FontSize, _animationCurve));
-                        anim.Add(0.0, AnimationDuration, new Animation(v => placeholder.TranslationY = v, placeholder.TranslationY, 0, _animationCurve, () =>
-                        {
-                            placeholder.TextColor = PlaceholderColor;
-                            datePicker.Opacity = 1;
-                        }));
-                    }
-
-                    if (ShouldAnimateUnderline)
-                    {
-                        anim.Add(0.0, AnimationDuration, new Animation(v => underline.WidthRequest = v, Width, 0, _animationCurve, () => underline.HorizontalOptions = LayoutOptions.Center));
-                    }
-
-                    anim.Commit(this, "Anim2", rate: 2, length: (uint)(AnimationDuration * 1000), easing: _animationCurve);
-                });
-            }
-        }
-
-        private void ChangeToErrorState()
-        {
-            const int animDuration = 250;
-
-            placeholder.TextColor = (FloatingPlaceholderEnabled && datePicker.IsFocused) || (FloatingPlaceholderEnabled && datePicker.NullableDate.HasValue) ? ErrorColor : PlaceholderColor;
-            counter.TextColor = ErrorColor;
-            underline.Color = ShouldAnimateUnderline ? ErrorColor : Color.Transparent;
-            persistentUnderline.Color = AlwaysShowUnderline ? ErrorColor : Color.Transparent;
-            trailingIcon.IsVisible = true;
-            trailingIcon.Source = "xf_error";
-            trailingIcon.TintColor = ErrorColor;
-
-            if (string.IsNullOrEmpty(ErrorText))
-            {
-                helper.TextColor = ErrorColor;
-            }
-            else
-            {
-                Device.BeginInvokeOnMainThread(async () =>
-                {
-                    await helper.FadeTo(0, animDuration / 2, _animationCurve);
-                    helper.TranslationY = -4;
                     helper.TextColor = ErrorColor;
-                    helper.Text = ErrorText;
-                    await Task.WhenAll(helper.FadeTo(1, animDuration / 2, _animationCurve), helper.TranslateTo(0, 0, animDuration / 2, _animationCurve));
-                });
+                }
+                else
+                {
+                    await helper.FadeTo(0, AnimDurationMs, _animationCurve);
+                    helper.TextColor = ErrorColor;
+                    OnPropertyChanged(nameof(SmallText));
+                    helper.TranslationY = -4;
+                    await Task.WhenAll(
+                        helper.FadeTo(1, AnimDurationMs, _animationCurve),
+                        helper.TranslateTo(0, 0, AnimDurationMs, _animationCurve));
+                }
             }
-        }
-
-        private void ChangeToNormalState()
-        {
-            const double opactiy = 1;
-
-            IsEnabled = true;
-            datePicker.Opacity = opactiy;
-            placeholder.Opacity = opactiy;
-            helper.Opacity = opactiy;
-            underline.Opacity = opactiy;
-
-            Device.BeginInvokeOnMainThread(async () =>
+            else
             {
                 trailingIcon.IsVisible = false;
+                trailingIcon.Source = "xf_arrow_dropdown";
 
-                var accentColor = TintColor;
-                placeholder.TextColor = accentColor;
+                placeholder.TextColor = tintColor;
                 counter.TextColor = HelperTextColor;
-                underline.Color = accentColor;
-                persistentUnderline.Color = UnderlineColor;
+                UnderlineSetColorState();
 
                 if (string.IsNullOrEmpty(ErrorText))
                 {
@@ -865,92 +497,141 @@ namespace XF.Material.Forms.UI
                 }
                 else
                 {
-                    await helper.FadeTo(0, 150, _animationCurve);
-                    helper.TranslationY = -4;
+                    await helper.FadeTo(0, AnimDurationMs, _animationCurve);
                     helper.TextColor = HelperTextColor;
-                    helper.Text = HelperText;
-                    await Task.WhenAll(helper.FadeTo(1, 150, _animationCurve), helper.TranslateTo(0, 0, 150, _animationCurve));
+                    OnPropertyChanged(nameof(SmallText));
+                    helper.TranslationY = -4;
+                    await Task.WhenAll(
+                        helper.FadeTo(1, AnimDurationMs, _animationCurve), 
+                        helper.TranslateTo(0, 0, AnimDurationMs, _animationCurve));
                 }
-            });
+            }
+        }
+
+        private void UnderlineSetState(Animation anim = null)
+        {
+            var isFocused = datePicker.IsFocused;
+            var hasValue = Date.HasValue;
+            
+            var hasLine = hasValue || isFocused;
+            var hasThickLine = isFocused;
+
+            var isLineVisible = underline.WidthRequest != 0;
+
+            if (anim == null || !ShouldAnimateUnderline)
+            {
+                if (hasLine)
+                {
+                    underline.WidthRequest = -1;
+                    underline.HorizontalOptions = LayoutOptions.FillAndExpand;
+                    if(hasThickLine)
+                        underline.HeightRequest = 2;
+                }
+                else
+                {
+                    underline.WidthRequest = 0;
+                    underline.HeightRequest = 0;
+                    underline.HorizontalOptions = LayoutOptions.Center;
+                }
+            }
+            else
+            {
+                if (hasLine)
+                {
+                    anim.Add(0, AnimDurationS, new Animation(v => underline.WidthRequest = v, 0, Width, _animationCurve, () =>
+                    {
+                        underline.WidthRequest = -1;
+                        underline.HorizontalOptions = LayoutOptions.FillAndExpand;
+                    }));
+                    anim.Add(0, AnimDurationS, new Animation(v => underline.HeightRequest = v, underline.HeightRequest, hasThickLine ? 2 : 1, _animationCurve));
+                }
+                else if(isLineVisible)
+                {
+                    anim.Add(0, AnimDurationS, new Animation(v => underline.WidthRequest = v, Width, 0, _animationCurve, () =>
+                    {
+                        underline.WidthRequest = 0;
+                        underline.HeightRequest = 0;
+                        underline.HorizontalOptions = LayoutOptions.Center;
+                    }));
+                }
+            }
+        }
+
+        private void UnderlineSetColorState()
+        {
+            var isFocused = datePicker.IsFocused;
+            var hasValue = Date.HasValue;
+
+            if(HasError)
+                underline.Color = ErrorColor;
+            else if(isFocused || hasValue)
+                underline.Color = TintColor;
+            else if(AlwaysShowUnderline)
+                underline.Color = UnderlineColor;
+            else
+                underline.Color = Color.Transparent;
         }
 
         private void DeviceDisplay_MainDisplayInfoChanged(object sender, DisplayInfoChangedEventArgs e)
         {
             if (e.DisplayInfo.Orientation != _lastDeviceDisplay.Orientation)
             {
-                if (datePicker.NullableDate.HasValue && ShouldAnimateUnderline)
-                {
-                    underline.WidthRequest = -1;
-                    underline.HorizontalOptions = LayoutOptions.FillAndExpand;
-                }
-
+                UnderlineSetState();
                 _lastDeviceDisplay = e.DisplayInfo;
             }
         }
 
-        private void Entry_Completed(object sender, EventArgs e)
-        {
-            Completed?.Invoke(this, EventArgs.Empty);
-        }
-
         private void DatePicker_Focused(object sender, FocusEventArgs e)
         {
-            _wasFocused = true;
-            FocusCommand?.Execute(datePicker.IsFocused);
+            FocusCommand?.Execute(e.IsFocused);
             Focused?.Invoke(this, e);
+            Device.BeginInvokeOnMainThread(() => UpdateState());
         }
 
-        private void DatePicker_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void DatePicker_Unfocused(object sender, FocusEventArgs e)
         {
-            switch (e.PropertyName)
-            {
-                case nameof(IsFocused) when !datePicker.NullableDate.HasValue:
-                    AnimateToInactiveOrFocusedState();
-                    break;
-
-                case nameof(IsFocused) when datePicker.NullableDate.HasValue:
-                    AnimateToActivatedState();
-                    break;
-            }
+            FocusCommand?.Execute(e.IsFocused);
+            Unfocused?.Invoke(this, e);
+            Device.BeginInvokeOnMainThread(() => UpdateState());
         }
 
-        private void Entry_SizeChanged(object sender, EventArgs e)
-        {
-            var baseHeight = FloatingPlaceholderEnabled ? 56 : 40;
-            var diff = datePicker.Height - 20;
-            var rawRowHeight = baseHeight + diff;
-            _autoSizingRow.Height = new GridLength(rawRowHeight);
+        //private void Entry_SizeChanged(object sender, EventArgs e)
+        //{
+            //var baseHeight = FloatingPlaceholderEnabled ? 56 : 40;
+            //var diff = datePicker.Height - 20;
+            //var rawRowHeight = baseHeight + diff;
+            //_autoSizingRow.Height = new GridLength(rawRowHeight);
 
-            var iconVerticalMargin = (_autoSizingRow.Height.Value - 24) / 2;
+            //var iconVerticalMargin = (_autoSizingRow.Height.Value - 24) / 2;
 
-            if (leadingIcon.IsVisible)
-            {
-                leadingIcon.Margin = new Thickness(HorizontalPadding.Left, iconVerticalMargin, 0, iconVerticalMargin);
-                datePicker.Margin = new Thickness(12, datePicker.Margin.Top, HorizontalPadding.Right, datePicker.Margin.Bottom);
-            }
-            else
-            {
-                datePicker.Margin = new Thickness(HorizontalPadding.Left, datePicker.Margin.Top, HorizontalPadding.Right, datePicker.Margin.Bottom);
-            }
+            //if (leadingIcon.IsVisible)
+            //{
+            //    leadingIcon.Margin = new Thickness(HorizontalPadding.Left, iconVerticalMargin, 0, iconVerticalMargin);
+            //    datePicker.Margin = new Thickness(12, datePicker.Margin.Top, HorizontalPadding.Right, datePicker.Margin.Bottom);
+            //}
+            //else
+            //{
+            //    datePicker.Margin = new Thickness(HorizontalPadding.Left, datePicker.Margin.Top, HorizontalPadding.Right, datePicker.Margin.Bottom);
+            //}
 
-            if (trailingIcon.IsVisible)
-            {
-                var entryPaddingLeft = leadingIcon.IsVisible ? 12 : HorizontalPadding;
-                trailingIcon.Margin = new Thickness(12, iconVerticalMargin, HorizontalPadding.Right, iconVerticalMargin);
-                datePicker.Margin = new Thickness(entryPaddingLeft.Left, datePicker.Margin.Top, 0, datePicker.Margin.Bottom);
-            }
+            //if (trailingIcon.IsVisible)
+            //{
+            //    var entryPaddingLeft = leadingIcon.IsVisible ? 12 : HorizontalPadding;
+            //    trailingIcon.Margin = new Thickness(12, iconVerticalMargin, HorizontalPadding.Right, iconVerticalMargin);
+            //    datePicker.Margin = new Thickness(entryPaddingLeft.Left, datePicker.Margin.Top, 0, datePicker.Margin.Bottom);
+            //}
 
-            helper.Margin = new Thickness(HorizontalPadding.Left, helper.Margin.Top, 12, 0);
-            counter.Margin = new Thickness(0, counter.Margin.Top, HorizontalPadding.Right, 0);
+            //helper.Margin = new Thickness(HorizontalPadding.Left, helper.Margin.Top, 12, 0);
+            //counter.Margin = new Thickness(0, counter.Margin.Top, HorizontalPadding.Right, 0);
 
-            var placeholderLeftMargin = FloatingPlaceholderEnabled ? HorizontalPadding.Left : datePicker.Margin.Left;
-            placeholder.Margin = new Thickness(placeholderLeftMargin, 0, 0, 0);
+            //var placeholderLeftMargin = FloatingPlaceholderEnabled ? HorizontalPadding.Left : datePicker.Margin.Left;
+            //placeholder.Margin = new Thickness(placeholderLeftMargin, 0, 0, 0);
 
-            if (HasError)
-            {
-                underline.Color = ErrorColor;
-            }
-        }
+            //if (HasError)
+            //{
+            //    underline.Color = ErrorColor;
+            //}
+        //}
 
         private void DatePicker_DateChanged(object sender, NullableDateChangedEventArgs e)
         {
@@ -959,199 +640,55 @@ namespace XF.Material.Forms.UI
             DateChanged?.Invoke(this, e);
         }
 
-        private void DatePicker_Unfocused(object sender, FocusEventArgs e)
-        {
-            FocusCommand?.Execute(datePicker.IsFocused);
-            Unfocused?.Invoke(this, e);
-        }
-
-
-        private void OnAlwaysShowUnderlineChanged(bool isShown)
-        {
-            persistentUnderline.IsVisible = isShown;
-            persistentUnderline.Color = UnderlineColor;
-        }
-
-        private void OnBackgroundColorChanged(Color backgroundColor)
-        {
-            backgroundCard.BackgroundColor = backgroundColor;
-        }
-
-
         private void OnEnabledChanged(bool isEnabled)
         {
             Opacity = isEnabled ? 1 : 0.33;
-            helper.IsVisible = isEnabled && !string.IsNullOrEmpty(HelperText);
-        }
-
-        private void OnErrorColorChanged(Color errorColor)
-        {
-            trailingIcon.TintColor = errorColor;
+            OnPropertyChanged(nameof(IsHelperVisible));
         }
 
         private void OnErrorTextChanged()
         {
-            if (HasError)
-            {
-                ChangeToErrorState();
-            }
+            OnPropertyChanged(nameof(SmallText));
         }
 
-        private void OnFloatingPlaceholderEnabledChanged(bool isEnabled)
+        private void OnFloatingPlaceholderEnabledChanged()
         {
-            double marginTopVariation = Device.RuntimePlatform == Device.iOS ? 18 : 20;
-            datePicker.Margin = isEnabled ? new Thickness(datePicker.Margin.Left, 24, datePicker.Margin.Right, 0) : new Thickness(datePicker.Margin.Left, marginTopVariation - 9, datePicker.Margin.Right, 0);
+            _autoSizingRow.Height = FloatingPlaceholderEnabled ? new GridLength(54) : GridLength.Auto;
+            UpdateState(false);
 
-            var iconMargin = leadingIcon.Margin;
-            leadingIcon.Margin = isEnabled ? new Thickness(iconMargin.Left, 16, iconMargin.Right, 16) : new Thickness(iconMargin.Left, 8, iconMargin.Right, 8);
+        //    double marginTopVariation = Device.RuntimePlatform == Device.iOS ? 18 : 20;
+        //    datePicker.Margin = isEnabled ? new Thickness(datePicker.Margin.Left, 24, datePicker.Margin.Right, 0) : new Thickness(datePicker.Margin.Left, marginTopVariation - 9, datePicker.Margin.Right, 0);
 
-            var trailingIconMargin = trailingIcon.Margin;
-            trailingIcon.Margin = isEnabled ? new Thickness(trailingIconMargin.Left, 16, trailingIconMargin.Right, 16) : new Thickness(trailingIconMargin.Left, 8, trailingIconMargin.Right, 8);
+        //    var iconMargin = leadingIcon.Margin;
+        //    leadingIcon.Margin = isEnabled ? new Thickness(iconMargin.Left, 16, iconMargin.Right, 16) : new Thickness(iconMargin.Left, 8, iconMargin.Right, 8);
+
+        //    var trailingIconMargin = trailingIcon.Margin;
+        //    trailingIcon.Margin = isEnabled ? new Thickness(trailingIconMargin.Left, 16, trailingIconMargin.Right, 16) : new Thickness(trailingIconMargin.Left, 8, trailingIconMargin.Right, 8);
         }
 
-        private void OnHasErrorChanged()
+        private void OnHelperTextChanged()
         {
-            if (HasError)
-            {
-                ChangeToErrorState();
-            }
-            else
-            {
-                ChangeToNormalState();
-            }
-        }
-
-        private void OnHelperTextChanged(string helperText)
-        {
-            helper.Text = helperText;
-            helper.IsVisible = !string.IsNullOrEmpty(helperText);
-        }
-
-        private void OnHelperTextColorChanged(Color textColor)
-        {
-            helper.TextColor = counter.TextColor = textColor;
-        }
-
-        private void OnHelpertTextFontFamilyChanged(string fontFamily)
-        {
-            helper.FontFamily = counter.FontFamily = fontFamily;
-        }
-
-        private void OnLeadingIconChanged(string icon)
-        {
-            leadingIcon.Source = icon;
-            OnLeadingIconTintColorChanged(LeadingIconTintColor);
-        }
-
-        private void OnLeadingIconTintColorChanged(Color tintColor)
-        {
-            leadingIcon.TintColor = tintColor;
-        }
-
-        private void OnPlaceholderChanged(string placeholderText)
-        {
-            placeholder.Text = placeholderText;
-        }
-
-        private void OnPlaceholderColorChanged(Color placeholderColor)
-        {
-            placeholder.TextColor = placeholderColor;
-        }
-
-        private void OnPlaceholderFontFamilyChanged(string fontFamily)
-        {
-            placeholder.FontFamily = fontFamily;
+            OnPropertyChanged(nameof(SmallText));
+            OnPropertyChanged(nameof(IsHelperVisible));
         }
 
         private void OnDateChanged(DateTime? date)
         {
             datePicker.NullableDate = date;
             clearIcon.IsVisible = date.HasValue;
-            AnimateToInactiveOrFocusedStateOnStart(this);
+            Device.BeginInvokeOnMainThread(() => UpdateState());
         }
 
-        private void OnTextColorChanged(Color textColor)
+        private void OnClear(object sender, EventArgs e)
         {
-            datePicker.TextColor = trailingIcon.TintColor = textColor;
+            if (Date != null)
+                Date = null;
         }
 
-        private void OnTextFontFamilyChanged(string fontFamily)
+        private void OnTap(object sender, EventArgs e)
         {
-            datePicker.FontFamily = fontFamily;
-        }
-
-        private void OnTextFontSizeChanged(double fontSize)
-        {
-            placeholder.FontSize = datePicker.FontSize = fontSize;
-        }
-
-        private void OnTintColorChanged(Color tintColor)
-        {
-            datePicker.TintColor = tintColor;
-        }
-
-        private void OnUnderlineColorChanged(Color underlineColor)
-        {
-            if (AlwaysShowUnderline)
-            {
-                persistentUnderline.Color = underlineColor;
-            }
-        }
-
-        private void SetControl()
-        {
-            trailingIcon.TintColor = TextColor;
-
-            clearIcon.TintColor = TextColor;
-            clearIcon.Source = ClearIcon;
-            clearIcon.GestureRecognizers.Add(new TapGestureRecognizer()
-            {
-                Command = new Command(() =>
-                {
-                    if (Date != null)
-                    {
-                        Date = null;
-                    }
-                })
-            });
-
-            persistentUnderline.Color = UnderlineColor;
-
-            tapGesture.Command = new Command(() =>
-            {
-                if (!datePicker.IsFocused)
-                {
-                    datePicker.Focus();
-                }
-            });
-        }
-
-        private void SetPropertyChangeHandler(ref Dictionary<string, Action> propertyChangeActions)
-        {
-            propertyChangeActions = new Dictionary<string, Action>
-            {
-                { nameof(Date), () => OnDateChanged(Date) },
-                { nameof(TextColor), () => OnTextColorChanged(TextColor) },
-                { nameof(TextFontFamily), () => OnTextFontFamilyChanged(TextFontFamily) },
-                { nameof(TintColor), () => OnTintColorChanged(TintColor) },
-                { nameof(Placeholder), () => OnPlaceholderChanged(Placeholder) },
-                { nameof(PlaceholderColor), () => OnPlaceholderColorChanged(PlaceholderColor) },
-                { nameof(PlaceholderFontFamily), () => OnPlaceholderFontFamilyChanged(PlaceholderFontFamily) },
-                { nameof(HelperText), () => OnHelperTextChanged(HelperText) },
-                { nameof(HelperTextFontFamily), () => OnHelpertTextFontFamilyChanged(HelperTextFontFamily) },
-                { nameof(HelperTextColor), () => OnHelperTextColorChanged(HelperTextColor) },
-                { nameof(IsEnabled), () => OnEnabledChanged(IsEnabled) },
-                { nameof(BackgroundColor), () => OnBackgroundColorChanged(BackgroundColor) },
-                { nameof(AlwaysShowUnderline), () => OnAlwaysShowUnderlineChanged(AlwaysShowUnderline) },
-                { nameof(ErrorColor), () => OnErrorColorChanged(ErrorColor) },
-                { nameof(UnderlineColor), () => OnUnderlineColorChanged(UnderlineColor) },
-                { nameof(HasError), () => OnHasErrorChanged() },
-                { nameof(FloatingPlaceholderEnabled), () => OnFloatingPlaceholderEnabledChanged(FloatingPlaceholderEnabled) },
-                { nameof(LeadingIcon), () => OnLeadingIconChanged(LeadingIcon) },
-                { nameof(LeadingIconTintColor), () => OnLeadingIconTintColorChanged(LeadingIconTintColor) },
-                { nameof(TextFontSize), () => OnTextFontSizeChanged(TextFontSize) },
-                { nameof(ErrorText), () => OnErrorTextChanged() }
-            };
+            if (!datePicker.IsFocused)
+                datePicker.Focus();
         }
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It fixes all the display behavior bugs happening on this material datepicker

### :arrow_heading_down: What is the current behavior?
- the date is selected on android, even if the cancel button is tapped in the calendar
- the color of the underline is inconsistent with the control's state, especially visible if a custom tint was selected
- the floating label's color is inconsistent with the control's state
- on iOS, a grey border is displayed around the internal date picker

### :new: What is the new behavior (if this is a feature change)?
Above behaviors are fixed

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Use the sample project

### :memo: Links to relevant issues/docs
None

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
