### PR TITLE
New MaterialTextFieldInputType.SingleImmediateChoice

### DIFF
--- a/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
@@ -24,6 +24,9 @@
             <material:MaterialTextField Placeholder="Choices"
                                         InputType="Choice"
                                         Choices="{Binding Choices}"/>
+            <material:MaterialTextField Placeholder="Quick single choice"
+                                        InputType="SingleImmediateChoice"
+                                        Choices="{Binding Choices}"/>
             <material:MaterialDateField Placeholder="Date" />
             <material:MaterialDateField Placeholder="Date and tips"
                                         HelperText="Your birthday"

--- a/XF.Material/UI/Dialogs/IMaterialDialog.cs
+++ b/XF.Material/UI/Dialogs/IMaterialDialog.cs
@@ -103,8 +103,9 @@ namespace XF.Material.Forms.UI.Dialogs
         /// <param name="confirmingText">The text of the confirmation button.</param>
         /// <param name="dismissiveText">The text of the dismissive button</param>
         /// <param name="configuration">The style of the confirmation dialog.</param>
+        /// <param name="closeOnSelection">If true, no buttons are displayed and validation occurs when clicking an item</param>
         /// <exception cref="ArgumentNullException" />
-        Task<int> SelectChoiceAsync(string title, IList<string> choices, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null);
+        Task<int> SelectChoiceAsync(string title, IList<string> choices, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null, bool closeOnSelection = false);
 
         /// <summary>
         /// Shows a confirmation dialog that allows the user to select one of the listed choices. Returns the index of the selected choice. If none was selected, returns -1.
@@ -115,9 +116,10 @@ namespace XF.Material.Forms.UI.Dialogs
         /// <param name="confirmingText">The text of the confirmation button.</param>
         /// <param name="dismissiveText">The text of the dismissive button</param>
         /// <param name="configuration">The style of the confirmation dialog.</param>
+        /// <param name="closeOnSelection">If true, no buttons are displayed and validation occurs when clicking an item</param>
         /// <exception cref="ArgumentNullException" />
         /// <exception cref="IndexOutOfRangeException" />
-        Task<int> SelectChoiceAsync(string title, IList<string> choices, int selectedIndex, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null);
+        Task<int> SelectChoiceAsync(string title, IList<string> choices, int selectedIndex, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null, bool closeOnSelection = false);
 
         /// <summary>
         /// Shows a confirmation dialog that allows the user to select any of the listed choices. Returns the indices of the selected choices. If none was selected, returns an empty array.

--- a/XF.Material/UI/Dialogs/MaterialConfirmationDialog.xaml.cs
+++ b/XF.Material/UI/Dialogs/MaterialConfirmationDialog.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xamarin.Essentials;
 using Xamarin.Forms;
@@ -75,9 +76,9 @@ namespace XF.Material.Forms.UI.Dialogs
             bindable.SetValue(DialogTitleProperty, title);
         }
 
-        public static async Task<object> ShowSelectChoiceAsync(string title, IList<string> choices, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null)
+        public static async Task<object> ShowSelectChoiceAsync(string title, IList<string> choices, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null, bool closeOnSelection = false)
         {
-            var dialog = new MaterialConfirmationDialog(configuration)
+            using var dialog = new MaterialConfirmationDialog(configuration)
             {
                 InputTaskCompletionSource = new TaskCompletionSource<object>(),
                 _radioButtonGroup = new MaterialRadioButtonGroup
@@ -95,19 +96,25 @@ namespace XF.Material.Forms.UI.Dialogs
                 dialog._radioButtonGroup.TextColor = dialog._preferredConfig.TextColor;
             }
 
+            if (closeOnSelection)
+            {
+                dialog.PositiveButton.IsVisible = false;
+                dialog._radioButtonGroup.SelectedIndexChanged += (sender, args) => dialog.PositiveButton_Clicked(sender, EventArgs.Empty);
+            }
+
             dialog._radioButtonGroup.ShouldShowScrollbar = true;
             dialog.DialogTitle.Text = !string.IsNullOrEmpty(title) ? title : throw new ArgumentNullException(nameof(title));
             dialog.PositiveButton.Text = confirmingText;
             dialog.NegativeButton.Text = dismissiveText;
             dialog.container.Content = dialog._radioButtonGroup;
-            await dialog.ShowAsync();
+            await dialog.ShowAsync().ConfigureAwait(false);
 
-            return await dialog.InputTaskCompletionSource.Task;
+            return await dialog.InputTaskCompletionSource.Task.ConfigureAwait(false);
         }
 
-        public static async Task<object> ShowSelectChoiceAsync(string title, IList<string> choices, int selectedIndex, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null)
+        public static async Task<object> ShowSelectChoiceAsync(string title, IList<string> choices, int selectedIndex, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null, bool closeOnSelection = false)
         {
-            var dialog = new MaterialConfirmationDialog(configuration)
+            using var dialog = new MaterialConfirmationDialog(configuration)
             {
                 InputTaskCompletionSource = new TaskCompletionSource<object>(),
                 _radioButtonGroup = new MaterialRadioButtonGroup
@@ -126,15 +133,21 @@ namespace XF.Material.Forms.UI.Dialogs
                 dialog._radioButtonGroup.TextColor = dialog._preferredConfig.TextColor;
             }
 
+            if (closeOnSelection)
+            {
+                dialog.PositiveButton.IsVisible = false;
+                dialog._radioButtonGroup.SelectedIndexChanged += (sender, args) => dialog.PositiveButton_Clicked(sender, EventArgs.Empty);
+            }
+
             dialog._radioButtonGroup.ShouldShowScrollbar = true;
             dialog.DialogTitle.Text = !string.IsNullOrEmpty(title) ? title : throw new ArgumentNullException(nameof(title));
             dialog.container.Content = dialog._radioButtonGroup;
             dialog.PositiveButton.IsEnabled = true;
             dialog.PositiveButton.Text = confirmingText;
             dialog.NegativeButton.Text = dismissiveText;
-            await dialog.ShowAsync();
+            await dialog.ShowAsync().ConfigureAwait(false);
 
-            return await dialog.InputTaskCompletionSource.Task;
+            return await dialog.InputTaskCompletionSource.Task.ConfigureAwait(false);
         }
 
         public static async Task<object> ShowSelectChoicesAsync(string title, IList<string> choices, string confirmingText = "Ok", string dismissiveText = "Cancel", MaterialConfirmationDialogConfiguration configuration = null)

--- a/XF.Material/UI/Dialogs/MaterialDialog.cs
+++ b/XF.Material/UI/Dialogs/MaterialDialog.cs
@@ -104,9 +104,10 @@ namespace XF.Material.Forms.UI.Dialogs
             IList<string> choices,
             string confirmingText = "Ok",
             string dismissiveText = "Cancel",
-            MaterialConfirmationDialogConfiguration configuration = null)
+            MaterialConfirmationDialogConfiguration configuration = null,
+            bool closeOnSelection = false)
         {
-            return (int)await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, confirmingText, dismissiveText, configuration);
+            return (int) await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, confirmingText, dismissiveText, configuration, closeOnSelection);
         }
 
         public async Task<int> SelectChoiceAsync(
@@ -115,9 +116,10 @@ namespace XF.Material.Forms.UI.Dialogs
             int selectedIndex,
             string confirmingText = "Ok",
             string dismissiveText = "Cancel",
-            MaterialConfirmationDialogConfiguration configuration = null)
+            MaterialConfirmationDialogConfiguration configuration = null,
+            bool closeOnSelection = false)
         {
-            return (int)await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, selectedIndex, confirmingText, dismissiveText, configuration);
+            return (int)await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, selectedIndex, confirmingText, dismissiveText, configuration, closeOnSelection);
         }
 
         public async Task<int[]> SelectChoicesAsync(

--- a/XF.Material/UI/Dialogs/MaterialDialogs.cs
+++ b/XF.Material/UI/Dialogs/MaterialDialogs.cs
@@ -140,9 +140,9 @@ namespace XF.Material.Forms.Dialogs
         /// <param name="title">The title of the confirmation dialog. This parameter must not be null or empty.</param>
         /// <param name="choices">The list of choices the user will choose from.</param>
         /// <exception cref="ArgumentNullException" />
-        public static async Task<int> ShowSelectChoiceAsync(string title, IList<string> choices, MaterialConfirmationDialogConfiguration configuration = null)
+        public static async Task<int> ShowSelectChoiceAsync(string title, IList<string> choices, MaterialConfirmationDialogConfiguration configuration = null, bool closeOnSelection = false)
         {
-            return (int)await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, null, null, configuration);
+            return (int)await MaterialConfirmationDialog.ShowSelectChoiceAsync(title, choices, null, null, configuration, closeOnSelection);
         }
 
         /// <summary>

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -200,7 +200,7 @@ namespace XF.Material.Forms.UI
         }
 
         /// <summary>
-        /// Gets or sets the collection of objects which the user will choose from. This is required when <see cref="InputType"/> is set to <see cref="MaterialTextFieldInputType.Choice"/>.
+        /// Gets or sets the collection of objects which the user will choose from. This is required when <see cref="InputType"/> is set to <see cref="MaterialTextFieldInputType.Choice"/> or <see cref="MaterialTextFieldInputType.SingleImmediateChoice"/>.
         /// </summary>
         public IList Choices
         {
@@ -221,7 +221,7 @@ namespace XF.Material.Forms.UI
 
 
         /// <summary>
-        /// Gets or sets the command that will execute if a choice was selected when the <see cref="InputType"/> is set to <see cref="MaterialTextFieldInputType.Choice"/>.
+        /// Gets or sets the command that will execute if a choice was selected when the <see cref="InputType"/> is set to <see cref="MaterialTextFieldInputType.Choice"/> or <see cref="MaterialTextFieldInputType.SingleImmediateChoice"/>.
         /// </summary>
         public ICommand ChoiceSelectedCommand
         {
@@ -869,7 +869,7 @@ namespace XF.Material.Forms.UI
 
             Device.BeginInvokeOnMainThread(async () =>
             {
-                if (InputType == MaterialTextFieldInputType.Choice)
+                if (InputType == MaterialTextFieldInputType.Choice || InputType == MaterialTextFieldInputType.SingleImmediateChoice)
                 {
                     trailingIcon.Source = "xf_arrow_dropdown";
                     trailingIcon.TintColor = TextColor;
@@ -1201,14 +1201,15 @@ namespace XF.Material.Forms.UI
                     break;
 
                 case MaterialTextFieldInputType.Choice:
-
+                case MaterialTextFieldInputType.SingleImmediateChoice:
                     break;
             }
 
             // Hint: Will use this for MaterialTextArea
             // entry.AutoSize = inputType == MaterialTextFieldInputType.MultiLine ? EditorAutoSizeOption.TextChanges : EditorAutoSizeOption.Disabled;
-            _gridContainer.InputTransparent = InputType == MaterialTextFieldInputType.Choice;
-            trailingIcon.IsVisible = InputType == MaterialTextFieldInputType.Choice;
+            var isChoice = InputType == MaterialTextFieldInputType.Choice || InputType == MaterialTextFieldInputType.SingleImmediateChoice;
+            _gridContainer.InputTransparent = isChoice;
+            trailingIcon.IsVisible = isChoice;
 
             entry.IsNumericKeyboard = InputType == MaterialTextFieldInputType.Telephone || InputType == MaterialTextFieldInputType.Numeric;
             entry.IsPassword = InputType == MaterialTextFieldInputType.Password || InputType == MaterialTextFieldInputType.NumericPassword;
@@ -1278,11 +1279,11 @@ namespace XF.Material.Forms.UI
 
             if (_selectedIndex >= 0)
             {
-                result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, _selectedIndex, confirmingText, dismissiveText, configuration);
+                result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, _selectedIndex, confirmingText, dismissiveText, configuration, InputType == MaterialTextFieldInputType.SingleImmediateChoice);
             }
             else
             {
-                result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, confirmingText, dismissiveText, configuration);
+                result = await MaterialDialog.Instance.SelectChoiceAsync(title, _choices, confirmingText, dismissiveText, configuration, InputType == MaterialTextFieldInputType.SingleImmediateChoice);
             }
 
             if (result >= 0)
@@ -1295,21 +1296,23 @@ namespace XF.Material.Forms.UI
 
         private void OnTextChanged(string text)
         {
-            if (InputType == MaterialTextFieldInputType.Choice && !string.IsNullOrEmpty(text) && _choicesResults?.Contains(text) == false)
+            var isChoice = InputType == MaterialTextFieldInputType.Choice || InputType == MaterialTextFieldInputType.SingleImmediateChoice;
+
+            if (isChoice && !string.IsNullOrEmpty(text) && _choicesResults?.Contains(text) == false)
             {
                 Debug.WriteLine($"The `Text` property value `{Text}` does not match any item in the collection `Choices`.");
                 Text = null;
                 return;
             }
 
-            if (InputType == MaterialTextFieldInputType.Choice && !string.IsNullOrEmpty(text))
+            if (isChoice && !string.IsNullOrEmpty(text))
             {
                 var selectedChoice = GetSelectedChoice(_selectedIndex);
                 SelectedChoice = selectedChoice;
                 ChoiceSelected?.Invoke(this, new SelectedItemChangedEventArgs(selectedChoice, _selectedIndex));
                 ChoiceSelectedCommand?.Execute(selectedChoice);
             }
-            else if (InputType == MaterialTextFieldInputType.Choice && string.IsNullOrEmpty(text))
+            else if (isChoice && string.IsNullOrEmpty(text))
             {
                 _selectedIndex = -1;
             }

--- a/XF.Material/UI/MaterialTextFieldInputType.cs
+++ b/XF.Material/UI/MaterialTextFieldInputType.cs
@@ -15,6 +15,7 @@
         Url,
         Password,
         NumericPassword,
-        Choice
+        Choice,
+        SingleImmediateChoice
     }
 }


### PR DESCRIPTION
Added new `MaterialTextFieldInputType.SingleImmediateChoice` option, same as `Choice`, but without the OK button. 
Validation occurs immediately when an item is tapped.

It also dispose correctly these 2 dialogs using the new using; C# syntax.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add a new option to MaterialTextFieldInputType

### :arrow_heading_down: What is the current behavior?
N/A

### :new: What is the new behavior (if this is a feature change)?
When a MaterialTextField has its InputType set to SingleImmediateChoice, it will display a list of items in a material dialog.
When selecting an item, the dialog will automatically validate the choice and close.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
The test project has been updated in the material text field section.

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
