### PR TITLE
move renderer at the correct place

### DIFF
--- a/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
+++ b/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
@@ -102,7 +102,6 @@
     <Compile Include="Core\PlatformContainer.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
-    <Compile Include="Renderers\MaterialDatePickerRenderer.cs" />
     <Compile Include="Renderers\MViewCellRenderer.cs" />
     <None Include="Entitlements.plist" />
     <None Include="Info.plist" />

--- a/XF.Material/Platforms/Ios/Renderers/MaterialDatePickerRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialDatePickerRenderer.cs
@@ -1,4 +1,4 @@
-﻿using MaterialMvvmSample.iOS.Renderers;
+﻿using XF.Material.iOS.Renderers;
 using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
@@ -6,7 +6,7 @@ using XF.Material.Forms.UI.Internals;
 
 [assembly:ExportRenderer(typeof(MaterialDatePicker), typeof(MaterialDatePickerRenderer))]
 
-namespace MaterialMvvmSample.iOS.Renderers
+namespace XF.Material.iOS.Renderers
 {
     /// <summary>
     /// Remove border


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Quick fix of previous PR, where i put the renderer in the sample iOS project instead of the main XF library.

### :arrow_heading_down: What is the current behavior?
The fix won't be applied to those consuming the nuget.

### :new: What is the new behavior (if this is a feature change)?
fix is applied

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
N/A

### :memo: Links to relevant issues/docs
N/A

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
