### PR TITLE
Readonly MaterialTextField: disable focus on Entry. Also prevent a crash

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -927,9 +927,17 @@ namespace XF.Material.Forms.UI
 
         private void Entry_Focused(object sender, FocusEventArgs e)
         {
-            FocusCommand?.Execute(entry.IsFocused);
-            Focused?.Invoke(this, e);
-            UpdateCounter();
+            if (InputType == MaterialTextFieldInputType.Choice || InputType == MaterialTextFieldInputType.SingleImmediateChoice
+                                                               || InputType == MaterialTextFieldInputType.CommandChoice)
+            {
+                ((View) sender).Unfocus();
+            }
+            else
+            {
+                FocusCommand?.Execute(entry.IsFocused);
+                Focused?.Invoke(this, e);
+                UpdateCounter();
+            }
         }
 
         private void Entry_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -1017,7 +1025,7 @@ namespace XF.Material.Forms.UI
                     if (propInfo != null)
                     { 
                         var propValue = propInfo.GetValue(item);
-                        choice =propValue.ToString();
+                        choice =propValue?.ToString();
                     }
                 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fix1:
MaterialTextField with input type like Choice can be focused, mostly by the tab key when a keyboard is connected (but not only).
With this fix it can't be focused anymore.

Fix2:
Add a guard for a rare crash.

### :arrow_heading_down: What is the current behavior?

- MaterialTextField with input type like Choice can be focused, mostly by the tab key when a keyboard is connected (but not only).
- Rare crash because of a missing test of null

### :new: What is the new behavior (if this is a feature change)?

It can't be focused anymore.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Use the tab key to move from field to field in the Android simulator, using the existing test project.

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
