### PR TITLE
fix Multiple choice issue in MaterialRadioButtonGroup

### DIFF
--- a/XF.Material/UI/MaterialRadioButtonGroup.xaml.cs
+++ b/XF.Material/UI/MaterialRadioButtonGroup.xaml.cs
@@ -110,8 +110,10 @@ namespace XF.Material.Forms.UI
 
             if (SelectedIndex >= 0 && Models?.Any() == true)
             {
-                var model = Models[SelectedIndex];
-                model.IsSelected = true;
+                for (var i = 0; i < Models.Count; i++)
+                {
+                    Models[i].IsSelected = i == SelectedIndex;
+                }
             }
 
             OnSelectedIndexChanged(SelectedIndex);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

bug fix
### :arrow_heading_down: What is the current behavior?

When you select a new item the previous selected item will not be deselected
### :new: What is the new behavior (if this is a feature change)?

When you select a new item the previous selected item will be deselected
### :boom: Does this PR introduce a breaking change?

No
### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#272 
### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
