### PR TITLE
fix crash in MaterialTextField in choice mode

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -55,7 +55,7 @@ namespace XF.Material.Forms.UI
                     if (control._selectedIndex != index)
                     {
                         control._selectedIndex = index;
-                        control.Text = control._choicesResults[index];
+                        control.Text = index>=0 ? control._choicesResults[index] : null;
                         control.AnimateToInactiveOrFocusedStateOnStart(control, false);
 
                         control.UpdateCounter();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix crash in MaterialTextField in choice mode

### :arrow_heading_down: What is the current behavior?
crash when selected item is not in list

### :new: What is the new behavior (if this is a feature change)?
don't crash

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
sample project

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
