### PR TITLE
make sure the control never crashes

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1296,7 +1296,9 @@ namespace XF.Material.Forms.UI
 
             if (Choices == null || Choices?.Count <= 0)
             {
-                throw new InvalidOperationException("The property `Choices` is null or empty");
+                //throw new InvalidOperationException("The property `Choices` is null or empty");
+                Console.WriteLine("Error in MaterialTextField: the property `Choices` is null or empty");
+                return;
             }
             _choices = GetChoices(out _choicesResults);
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

It make sure the control never crashes, even if the list of Choice is null or empty.

### :arrow_heading_down: What is the current behavior?

The control crashes when the list of Choice is null or empty, and the selecteditem is set.

### :new: What is the new behavior (if this is a feature change)?

Does not crash

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing
-

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
