### PR TITLE
MaterialTextField  will not crash  via embedding

### DIFF
--- a/XF.Material/Material.cs
+++ b/XF.Material/Material.cs
@@ -13,7 +13,7 @@ namespace XF.Material.Forms
     {
         private static readonly Lazy<IMaterialUtility> MaterialUtilityInstance = new Lazy<IMaterialUtility>(() => DependencyService.Get<IMaterialUtility>());
         private readonly MaterialConfiguration _config;
-        private readonly ResourceDictionary _res;
+        private static ResourceDictionary _res;
 
         internal Material(Application app, MaterialConfiguration materialResource) : this(app)
         {
@@ -49,7 +49,7 @@ namespace XF.Material.Forms
         /// <exception cref="ArgumentNullException" />
         public static T GetResource<T>(string key)
         {
-            Application.Current.Resources.TryGetValue(key ?? throw new ArgumentNullException(nameof(key)), out var value);
+            _res.TryGetValue(key ?? throw new ArgumentNullException(nameof(key)), out var value);
 
             if (value is T resource)
             {

--- a/XF.Material/UI/MaterialLabel.cs
+++ b/XF.Material/UI/MaterialLabel.cs
@@ -74,17 +74,17 @@ namespace XF.Material.Forms.UI
             if (!_letterSpacingChanged)
             {
                 var letterSpacingKey = $"Material.LetterSpacing.{materialTypeScale.ToString()}";
-                LetterSpacing = Convert.ToDouble(Application.Current.Resources[letterSpacingKey]);
+                LetterSpacing = Material.GetResource<double>(letterSpacingKey);
             }
             if (!_fontFamilyChanged)
             {
                 var fontFamilyKey = $"Material.FontFamily.{materialTypeScale.ToString()}";
-                FontFamily = Application.Current.Resources[fontFamilyKey]?.ToString();
+                FontFamily = Material.GetResource<string>(fontFamilyKey);
             }
             if (!_fontSizeChanged)
             {
                 var fontSizeKey = $"Material.FontSize.{materialTypeScale.ToString()}";
-                FontSize = Convert.ToDouble(Application.Current.Resources[fontSizeKey]);
+                FontSize = Material.GetResource<double>(fontSizeKey);
             }
 
             if (_fontAttributeChanged)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

bug fix
### :arrow_heading_down: What is the current behavior?

The resource 'Material.LetterSpacing.Body2' is not present in the dictionary  via embedding
### :new: What is the new behavior (if this is a feature change)?

It works well via embedding
### :boom: Does this PR introduce a breaking change?

no
### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

https://github.com/Baseflow/XF-Material-Library/issues/318
### :thinking: Checklist before submitting

- [x] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
