### PR TITLE
Fixed typo that caused the CardBackgroundColor property not able to b…

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml
+++ b/XF.Material/UI/MaterialTextField.xaml
@@ -30,7 +30,7 @@
                 x:Name="backgroundCard"
                 Grid.Row="0"
                 Grid.ColumnSpan="3"
-                BackgroundColor="{Binding CardBackgroudColor,Source={x:Reference ThisControl}}"
+                BackgroundColor="{Binding CardBackgroundColor,Source={x:Reference ThisControl}}"
                 CornerRadius="4,4,0,0" />
             <material:MaterialIcon
                 x:Name="leadingIcon"

--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -25,7 +25,7 @@ namespace XF.Material.Forms.UI
     {
         public static readonly BindableProperty AlwaysShowUnderlineProperty = BindableProperty.Create(nameof(AlwaysShowUnderline), typeof(bool), typeof(MaterialTextField), false);
 
-        public static readonly BindableProperty CardBackgroundColorProperty = BindableProperty.Create(nameof(CardBackgroudColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#DCDCDC"));
+        public static readonly BindableProperty CardBackgroundColorProperty = BindableProperty.Create(nameof(CardBackgroundColor), typeof(Color), typeof(MaterialTextField), Color.FromHex("#DCDCDC"));
 
         public static readonly BindableProperty ChoiceSelectedCommandProperty = BindableProperty.Create(nameof(ChoiceSelectedCommand), typeof(ICommand), typeof(MaterialTextField));
 
@@ -192,7 +192,7 @@ namespace XF.Material.Forms.UI
         /// <summary>
         /// Gets or sets the background color of this text field.
         /// </summary>
-        public Color CardBackgroudColor
+        public Color CardBackgroundColor
         {
             get => (Color)GetValue(CardBackgroundColorProperty);
             set => SetValue(CardBackgroundColorProperty, value);
@@ -1069,7 +1069,7 @@ namespace XF.Material.Forms.UI
             if (base.BackgroundColor != Color.Transparent)
             {
                 if(base.BackgroundColor != Color.Default)
-                    CardBackgroudColor = base.BackgroundColor;
+                    CardBackgroundColor = base.BackgroundColor;
                 base.BackgroundColor = Color.Transparent;
             }
         }


### PR DESCRIPTION

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MaterialTextField CardbackgroundColor not being able to be referred in a Style

### :new: What is the new behavior (if this is a feature change)?
Property can now be referred

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
