### PR TITLE
fixes #377

### DIFF
--- a/Samples/MaterialMvvmSample/App.xaml
+++ b/Samples/MaterialMvvmSample/App.xaml
@@ -7,6 +7,7 @@
              xmlns:ui="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material">
     <Application.Resources>
 
+        <!-- Breaks hot reload -->
         <OnPlatform x:Key="FontFamily.Exo2Regular"
                     x:TypeArguments="x:String"
                     Android="Fonts/Exo2-Regular.ttf#Exo2-Regular"
@@ -56,11 +57,12 @@
                                          OnPrimary="#FFFFFF"
                                          OnSecondary="#FFFFFF"
                                          OnSurface="#000000"
-                                         Primary="#6200EE"
-                                         PrimaryVariant="#6200EE"
+                                         Primary="#6250EE"
+                                         PrimaryVariant="#6280EE"
                                          Secondary="#00377b"
                                          Surface="#FFFFFF" />
 
+        <!-- Does not support DynamicResource (why?) -->
         <mtrl:MaterialConfiguration x:Key="Material.Style"
                                     ColorConfiguration="{StaticResource Material.Color}"
                                     FontConfiguration="{StaticResource Material.Font}" />

--- a/Samples/MaterialMvvmSample/App.xaml.cs
+++ b/Samples/MaterialMvvmSample/App.xaml.cs
@@ -14,8 +14,6 @@ namespace MaterialMvvmSample
             InitializeComponent();
             XF.Material.Forms.Material.Use("Material.Style");
 
-            XamSvg.Shared.Config.ResourceAssembly = typeof(App).Assembly;
-
             navigationService.SetRootView(ViewNames.LandingView);
         }
 

--- a/Samples/MaterialMvvmSample/App.xaml.cs
+++ b/Samples/MaterialMvvmSample/App.xaml.cs
@@ -10,9 +10,10 @@ namespace MaterialMvvmSample
     {
         public App(INavigationService navigationService)
         {
+            XF.Material.Forms.Material.Init(this);
             InitializeComponent();
+            XF.Material.Forms.Material.Use("Material.Style");
 
-            XF.Material.Forms.Material.Init(this, "Material.Style");
             XamSvg.Shared.Config.ResourceAssembly = typeof(App).Assembly;
 
             navigationService.SetRootView(ViewNames.LandingView);

--- a/XF.Material/Material.cs
+++ b/XF.Material/Material.cs
@@ -12,17 +12,21 @@ namespace XF.Material.Forms
     public class Material
     {
         private static readonly Lazy<IMaterialUtility> MaterialUtilityInstance = new Lazy<IMaterialUtility>(() => DependencyService.Get<IMaterialUtility>());
-        private readonly MaterialConfiguration _config;
+        private MaterialConfiguration _config;
         private static ResourceDictionary _res;
+
+        private static Material Instance;
 
         internal Material(Application app, MaterialConfiguration materialResource) : this(app)
         {
             _config = materialResource;
+            Instance = this;
         }
 
         internal Material(Application app, string key) : this(app)
         {
             _config = GetResource<MaterialConfiguration>(key);
+            Instance = this;
         }
 
         internal Material(Application app)
@@ -33,6 +37,15 @@ namespace XF.Material.Forms
                 ColorConfiguration = new MaterialColorConfiguration(),
                 FontConfiguration = new MaterialFontConfiguration()
             };
+            Instance = this;
+        }
+
+        public static void Use(string key)
+        {
+            if (Instance == null)
+                Init(Application.Current);
+            // ReSharper disable once PossibleNullReferenceException
+            Instance._config = GetResource<MaterialConfiguration>(key);
         }
 
         /// <summary>
@@ -49,6 +62,9 @@ namespace XF.Material.Forms
         /// <exception cref="ArgumentNullException" />
         public static T GetResource<T>(string key)
         {
+            if(_res == null)
+                throw new Exception("You must call one of the Init() methods in App.xaml.cs before InitializeComponent()");
+
             _res.TryGetValue(key ?? throw new ArgumentNullException(nameof(key)), out var value);
 
             if (value is T resource)
@@ -76,17 +92,17 @@ namespace XF.Material.Forms
             material.MergeMaterialDictionaries();
         }
 
-        /// <summary>
-        /// Configure's the current app's resources by merging pre-defined Material resources and creating new resources based on the <see cref="MaterialConfiguration"/>'s properties.
-        /// </summary>
-        /// <param name="app">The cross-platform mobile application that is running.</param>
-        /// <param name="key">The key of the <see cref="MaterialConfiguration"/> object in the current app's resource dictionary.</param>
-        /// <exception cref="ArgumentNullException" />
-        public static void Init(Application app, string key)
-        {
-            var material = new Material(app ?? throw new ArgumentNullException(nameof(app)), key ?? throw new ArgumentNullException(nameof(key)));
-            material.MergeMaterialDictionaries();
-        }
+        ///// <summary>
+        ///// Configure's the current app's resources by merging pre-defined Material resources and creating new resources based on the <see cref="MaterialConfiguration"/>'s properties.
+        ///// </summary>
+        ///// <param name="app">The cross-platform mobile application that is running.</param>
+        ///// <param name="key">The key of the <see cref="MaterialConfiguration"/> object in the current app's resource dictionary.</param>
+        ///// <exception cref="ArgumentNullException" />
+        //public static void Init(Application app, string key)
+        //{
+        //    var material = new Material(app ?? throw new ArgumentNullException(nameof(app)), key ?? throw new ArgumentNullException(nameof(key)));
+        //    material.MergeMaterialDictionaries();
+        //}
 
         /// <summary>
         /// Configure's the current app's resources by merging pre-defined Material resources.


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix #377 

### :arrow_heading_down: What is the current behavior?

Ios and android sample projects crash on run

### :new: What is the new behavior (if this is a feature change)?

Ios and android sample project don't crash on run

### :boom: Does this PR introduce a breaking change?

Yes.
The Init(this, "xxxxx") method has been removed.
Call Init(this) instead before InitializeComponent(), and Use("xxxxx") after InitializeComponent()

### :bug: Recommendations for testing

Run sample projects

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
