### PR TITLE
Fix MaterialButton icons and shrinking with ellipsis issues on iOS

### DIFF
--- a/Samples/MaterialMvvmSample.iOS/Info.plist
+++ b/Samples/MaterialMvvmSample.iOS/Info.plist
@@ -21,7 +21,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>8.0</string>
+	<string>12.4</string>
 	<key>CFBundleDisplayName</key>
 	<string>MaterialMvvmSample</string>
 	<key>CFBundleVersion</key>

--- a/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
+++ b/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
@@ -62,6 +62,8 @@
     <MtouchLink>None</MtouchLink>
     <MtouchInterpreter>-all</MtouchInterpreter>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <CodesignKey>Apple Development: Benjamin Mayrargue (4FX9X5DS74)</CodesignKey>
+    <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -71,8 +73,9 @@
     <WarningLevel>4</WarningLevel>
     <MtouchArch>ARM64</MtouchArch>
     <ConsolePause>false</ConsolePause>
-    <CodesignKey>iPhone Developer</CodesignKey>
+    <CodesignKey>Apple Development: Benjamin Mayrargue (4FX9X5DS74)</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>none</DebugType>

--- a/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
+++ b/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
@@ -13,8 +13,8 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>MaterialMvvmSample.iOS</AssemblyName>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <ProvisioningType>automatic</ProvisioningType>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,14 +53,15 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchArch>ARM64</MtouchArch>
-    <CodesignKey>iPhone Developer: Danielle Dustin Catap (9VEQRZL4UZ)</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignProvision>Generic Dev Profile</CodesignProvision>
     <MtouchEnableSGenConc>true</MtouchEnableSGenConc>
     <MtouchFastDev>true</MtouchFastDev>
     <DeviceSpecificBuild>true</DeviceSpecificBuild>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <MtouchLink>None</MtouchLink>
+    <MtouchInterpreter>-all</MtouchInterpreter>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -183,6 +184,9 @@
     </PackageReference>
     <PackageReference Include="Rg.Plugins.Popup">
       <Version>2.0.0.5</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>4.5.0.617</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/Samples/MaterialMvvmSample/App.xaml
+++ b/Samples/MaterialMvvmSample/App.xaml
@@ -58,7 +58,7 @@
                                          OnSurface="#000000"
                                          Primary="#6200EE"
                                          PrimaryVariant="#6200EE"
-                                         Secondary="#00377b"
+                                         Secondary="#00407b"
                                          Surface="#FFFFFF" />
 
         <mtrl:MaterialConfiguration x:Key="Material.Style"

--- a/Samples/MaterialMvvmSample/Images/slideshow-black-18dp.svg
+++ b/Samples/MaterialMvvmSample/Images/slideshow-black-18dp.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="18px" height="18px"><path d="M0 0h24v24H0z" fill="none"/><path d="M10 8v8l5-4-5-4zm9-5H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z"/></svg>
+<svg width="13.5" height="13.5" fill="#000000" version="1.1" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+	<path d="m7 5v8l5-4zm9-5h-14c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-14c0-1.1-.9-2-2-2zm0 16h-14v-14h14z"/>
+</svg>

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="6.0.0" />
-    <PackageReference Include="Vapolia.Xamarin.Svg.Forms" Version="3.2.9" />
+    <PackageReference Include="Vapolia.Xamarin.Svg.Forms" Version="4.0.0-pre7" />
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.617" />
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.5" />
   </ItemGroup>

--- a/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
@@ -5,14 +5,26 @@
     x:Class="MaterialMvvmSample.Views.MaterialButtonView"
     xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
     xmlns:xamForms="clr-namespace:XamSvg.XamForms;assembly=XamSvg.XamForms">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="material:MaterialButton" x:Key="TestStyle" CanCascade="True">
+                <Setter Property="BackgroundColor" Value="DarkSlateGray" />
+                <Setter Property="TextColor" Value="GreenYellow" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     
     <StackLayout Padding="20">
-        <material:MaterialButton Text="Welkom" Clicked="Btn_Clicked"/>
+        <material:MaterialButton Text="Welcome XF.Material" Clicked="Btn_Clicked" Style="{StaticResource TestStyle}" />
 
         <material:MaterialButton AllCaps="True"
                                  ButtonType="Elevated"
                                  Elevation="2"
                                  PressedBackgroundColor="Red"
+                                 BackgroundColor="GreenYellow"
+                                 TextColor="DarkGreen"
+                                 BorderColor="DarkGreen"
+                                 BorderWidth="1"
                                  HorizontalOptions="Center"
                                  Text="Open Dialog"
                                  VerticalOptions="Center"

--- a/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
@@ -58,7 +58,7 @@
         </Grid>
 
         <Label Text="With icons:"/>
-        <material:MaterialButton Text="Left svg icon" ContentLayout="Left,10" HorizontalOptions="Start" Padding="0,0,35,0">
+        <material:MaterialButton Text="Left svg icon" ContentLayout="Left,10" HorizontalOptions="Start">
             <Button.ImageSource>
                 <xamForms:SvgImageSource Svg="images.slideshow-black-18dp.svg" Height="45" ColorMapping="000000=FFFFFF" />
             </Button.ImageSource>

--- a/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
@@ -3,19 +3,62 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="MaterialMvvmSample.Views.MaterialButtonView"
-    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material">
-    <ContentPage.Content>
-        <StackLayout Padding="20">
-            <material:MaterialButton Text="Welkom" Clicked="Btn_Clicked"/>
+    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
+    xmlns:xamForms="clr-namespace:XamSvg.XamForms;assembly=XamSvg.XamForms">
+    
+    <StackLayout Padding="20">
+        <material:MaterialButton Text="Welkom" Clicked="Btn_Clicked"/>
 
-            <material:MaterialButton AllCaps="True"
-                                     ButtonType="Elevated"
-                                     Elevation="2"
-                                     PressedBackgroundColor="Red"
-                                     HorizontalOptions="Center"
-                                     Text="Open Dialog"
-                                     VerticalOptions="Center"
-                                     Clicked="MaterialButton_Clicked"/>
-        </StackLayout>
-    </ContentPage.Content>
+        <material:MaterialButton AllCaps="True"
+                                 ButtonType="Elevated"
+                                 Elevation="2"
+                                 PressedBackgroundColor="Red"
+                                 HorizontalOptions="Center"
+                                 Text="Open Dialog"
+                                 VerticalOptions="Center"
+                                 Clicked="MaterialButton_Clicked"/>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <material:MaterialButton Text="Left" HorizontalOptions="Start"/>
+            <material:MaterialButton Text="Mid" Grid.Column="1"  />
+            <material:MaterialButton Text="Right" Grid.Column="2" HorizontalOptions="End"/>
+        </Grid>
+
+        <Label Text="Defaut xamarin buttons for comparison:"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button Text="Left" BackgroundColor="Yellow" ContentLayout="Left,30" HorizontalOptions="Start">
+                <Button.ImageSource>
+                    <xamForms:SvgImageSource Svg="images.slideshow-black-18dp.svg" Height="45" ColorMapping="000000=0000FF" />
+                </Button.ImageSource>
+            </Button>
+            <Button Text="Mid" Grid.Column="1" BackgroundColor="Yellow" />
+            <Button Text="Right" Grid.Column="2"  BackgroundColor="Yellow" HorizontalOptions="End" />
+        </Grid>
+
+        <Label Text="With icons:"/>
+        <material:MaterialButton Text="Left svg icon" ContentLayout="Left,10" HorizontalOptions="Start" Padding="0,0,35,0">
+            <Button.ImageSource>
+                <xamForms:SvgImageSource Svg="images.slideshow-black-18dp.svg" Height="45" ColorMapping="000000=FFFFFF" />
+            </Button.ImageSource>
+        </material:MaterialButton>
+        <material:MaterialButton Text="Left normal icon" ImageSource="ic_overflow" HorizontalOptions="Start" />
+
+        <material:MaterialButton Text="Right SVG icon" ContentLayout="Right,27" HorizontalOptions="Start">
+            <Button.ImageSource>
+                <xamForms:SvgImageSource Svg="images.slideshow-black-18dp" Height="45" ColorMapping="000000=FFFFFF" />
+            </Button.ImageSource>
+        </material:MaterialButton>
+        <material:MaterialButton Text="Right normal icon" ImageSource="ic_overflow" ContentLayout="Right" HorizontalOptions="Start" />
+    </StackLayout>
+
 </ContentPage>

--- a/XF.Material.sln
+++ b/XF.Material.sln
@@ -116,8 +116,6 @@ Global
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|ARM64.Build.0 = Debug|Any CPU
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|ARM64.Deploy.0 = Debug|Any CPU
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhone.Deploy.0 = Debug|Any CPU
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
 		{E05550C8-072A-4E3D-8D2B-B2D4B9C47C13}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
@@ -169,6 +167,7 @@ Global
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|ARM64.ActiveCfg = Debug|iPhoneSimulator
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|iPhone.Build.0 = Debug|iPhone
+		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{8DFEFB5E-6594-4FFA-B7C2-D3AEBB98DD70}.Debug|x64.ActiveCfg = Debug|iPhoneSimulator

--- a/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
@@ -21,31 +21,36 @@ namespace XF.Material.Droid.Renderers
         {
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _helper.Clean();
+            }
+            
+            base.Dispose(disposing);
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
         {
             base.OnElementChanged(e);
 
             if (Control == null)
-            {
                 return;
-            }
 
             if (e?.OldElement != null)
-            {
                 _helper.Clean();
-            }
 
             if (e?.NewElement == null)
-            {
                 return;
-            }
 
-            _materialButton = Element as MaterialButton;
+            _materialButton = (MaterialButton)Element;
             _helper = new MaterialDrawableHelper(_materialButton, Control);
             _helper.UpdateDrawable();
 
             Control.SetMinimumWidth((int)MaterialHelper.ConvertDpToPx(64));
             Control.SetAllCaps(_materialButton != null && _materialButton.AllCaps);
+            Control.SetMaxLines(1);
 
             SetButtonIcon();
             SetTextColors();
@@ -84,27 +89,27 @@ namespace XF.Material.Droid.Renderers
             var withIcon = !string.IsNullOrEmpty(_materialButton.Image) || !(_materialButton.ImageSource?.IsEmpty ?? true);
             _helper.UpdateHasIcon(withIcon);
 
-            if (!withIcon)
-            {
-                return;
-            }
+             if (!withIcon)
+                 return;
 
-            var drawable = Control.GetCompoundDrawables().FirstOrDefault(s => s != null);
-
-            if (drawable == null)
-            {
-                return;
-            }
-
-            var drawableCopy = drawable.GetDrawableCopy();
-            var width = _materialButton.ButtonType == MaterialButtonType.Text ? (int)MaterialHelper.ConvertDpToPx(18) : (int)MaterialHelper.ConvertDpToPx(18 + 4);
-            var height = (int)MaterialHelper.ConvertDpToPx(18);
-            var left = _materialButton.ButtonType == MaterialButtonType.Text ? 0 : (int)MaterialHelper.ConvertDpToPx(4);
-            drawableCopy.SetBounds(left, 0, width, height);
-            drawableCopy.TintDrawable(_materialButton.TextColor.ToAndroid());
-
-            Control.SetCompoundDrawables(drawableCopy, null, null, null);
-            Control.CompoundDrawablePadding = 0;
+             var drawable = Control.GetCompoundDrawables().FirstOrDefault(s => s != null);
+            
+             if (drawable == null)
+             {
+                 return;
+             }
+            
+             var drawableCopy = drawable.GetDrawableCopy();
+             var width = _materialButton.ButtonType == MaterialButtonType.Text ? (int)MaterialHelper.ConvertDpToPx(18) : (int)MaterialHelper.ConvertDpToPx(18 + 4);
+             var height = (int)MaterialHelper.ConvertDpToPx(18);
+             var left = _materialButton.ButtonType == MaterialButtonType.Text ? 0 : (int)MaterialHelper.ConvertDpToPx(4);
+             drawableCopy.SetBounds(left, 0, width, height);
+             drawableCopy.TintDrawable(_materialButton.TextColor.ToAndroid());
+            
+             Control.SetCompoundDrawables(drawableCopy, null, null, null);
+             Control.CompoundDrawablePadding = 0;
+             
+             Control.RequestLayout();
         }
         private void SetTextColors()
         {
@@ -129,10 +134,31 @@ namespace XF.Material.Droid.Renderers
             Control.SetTextColor(new ColorStateList(states, colors));
         }
 
+        /// <summary>
+        /// TODO: obsolete. Replaced by Button.CharacterSpacing.
+        /// </summary>
         private void SetTextLetterSpacing()
         {
             var rawLetterSpacing = _materialButton.LetterSpacing / Control.TextSize;
             Control.LetterSpacing = MaterialHelper.ConvertSpToPx(rawLetterSpacing);
+        }
+        
+        public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
+        {
+            var size = base.GetDesiredSize(widthConstraint, heightConstraint);
+            if (size.Request.Width > 0)
+            {
+                var withIcon = !string.IsNullOrEmpty(_materialButton.Image) || !(_materialButton.ImageSource?.IsEmpty ?? true);
+
+                var sr = size.Request;
+                if(withIcon)
+                    sr.Width += (int)MaterialHelper.ConvertDpToPx(18);
+                // if(_materialButton != null && !_materialButton.Padding.IsEmpty)
+                //     sr.Width += MaterialHelper.ConvertDpToPx(_materialButton.Padding.HorizontalThickness);
+                size.Request = sr;
+            }
+
+            return size;
         }
     }
 }

--- a/XF.Material/Platforms/Android/Renderers/MaterialDrawableHelper.cs
+++ b/XF.Material/Platforms/Android/Renderers/MaterialDrawableHelper.cs
@@ -98,39 +98,11 @@ namespace XF.Material.Droid.Renderers
 
         private void BindableButton_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            var prop = e?.PropertyName;
-
-            if (prop == null)
-            {
-                return;
-            }
-
-            if (_propertyChangeActions != null && _propertyChangeActions.TryGetValue(prop, out var handlePropertyChange))
-            {
+            var prop = e.PropertyName;
+            if (prop != null && _propertyChangeActions.TryGetValue(prop, out var handlePropertyChange))
                 handlePropertyChange();
-            }
         }
 
-        private GradientDrawable CreateShapeDrawable(float cornerRadius, int borderWidth, Color backgroundColor, Color borderColor)
-        {
-            GradientDrawable shapeDrawable;
-
-            if (_button.ButtonType != MaterialButtonType.Text)
-            {
-                shapeDrawable = _withIcon ? MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape_with_icon)
-                                          : MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape);
-            }
-            else
-            {
-                shapeDrawable = MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape_text);
-            }
-
-            shapeDrawable.SetCornerRadius(cornerRadius);
-            shapeDrawable.SetColor(backgroundColor);
-            shapeDrawable.SetStroke(borderWidth, borderColor);
-
-            return shapeDrawable;
-        }
 
         private Drawable GetDrawable()
         {
@@ -146,15 +118,7 @@ namespace XF.Material.Droid.Renderers
                     SetStates(stateListDrawable, normalStateDrawable, normalStateDrawable, disabledStateDrawable);
                 }
 
-                rippleDrawable.SetColor(new ColorStateList(new[]
-                    {
-                    new int[]{}
-                },
-                new int[]
-                {
-                    _pressedColor
-                }));
-
+                rippleDrawable.SetColor(new ColorStateList(new[] {new int[]{}}, new int[] {_pressedColor}));
                 return rippleDrawable;
             }
             else
@@ -179,6 +143,28 @@ namespace XF.Material.Droid.Renderers
 
                 return backgroundDrawable;
             }
+        }
+        
+        
+        private GradientDrawable CreateShapeDrawable(float cornerRadius, int borderWidth, Color backgroundColor, Color borderColor)
+        {
+            GradientDrawable shapeDrawable;
+
+            if (_button.ButtonType != MaterialButtonType.Text)
+            {
+                shapeDrawable = _withIcon ? MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape_with_icon)
+                    : MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape);
+            }
+            else
+            {
+                shapeDrawable = MaterialHelper.GetDrawableCopyFromResource<GradientDrawable>(Resource.Drawable.drawable_shape_text);
+            }
+
+            shapeDrawable.SetCornerRadius(cornerRadius);
+            shapeDrawable.SetColor(backgroundColor);
+            shapeDrawable.SetStroke(borderWidth, borderColor);
+
+            return shapeDrawable;
         }
 
         private RippleDrawable GetRippleDrawable()

--- a/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
@@ -358,6 +358,9 @@ namespace XF.Material.iOS.Renderers
                     CreateTextButtonLayer();
                     break;
             }
+            
+            _animationLayer.SetNeedsDisplay();
+            SetNeedsDisplay();
         }
 
         private void UpdateCornerRadius()

--- a/XF.Material/UI/MaterialButton.cs
+++ b/XF.Material/UI/MaterialButton.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 using XF.Material.Forms.Resources;
 
 namespace XF.Material.Forms.UI
@@ -13,19 +14,15 @@ namespace XF.Material.Forms.UI
         public const string MaterialButtonColorChanged = "BackgroundColorChanged";
 
         private static readonly Color OutlinedBorderColor = Color.FromHex("#1E000000");
+        private readonly string[] _colorPropertyNames = { nameof(BackgroundColor), nameof(PressedBackgroundColor), nameof(DisabledBackgroundColor) };
 
         public static readonly BindableProperty AllCapsProperty = BindableProperty.Create(nameof(AllCaps), typeof(bool), typeof(MaterialButton), true);
+        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
         public static readonly BindableProperty ButtonTypeProperty = BindableProperty.Create(nameof(ButtonType), typeof(MaterialButtonType), typeof(MaterialButton), MaterialButtonType.Elevated);
-
         public static readonly BindableProperty DisabledBackgroundColorProperty = BindableProperty.Create(nameof(DisabledBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
-
         public static readonly BindableProperty PressedBackgroundColorProperty = BindableProperty.Create(nameof(PressedBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
-
         public static readonly BindableProperty LetterSpacingProperty = BindableProperty.Create(nameof(LetterSpacing), typeof(double), typeof(MaterialButton), 1.25);
-
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(MaterialElevation), typeof(MaterialButton), new MaterialElevation(2, 8));
-
-        private readonly string[] _colorPropertyNames = { nameof(BackgroundColor), nameof(PressedBackgroundColor), nameof(DisabledBackgroundColor) };
 
         public MaterialButton()
         {
@@ -61,6 +58,18 @@ namespace XF.Material.Forms.UI
         {
             get => (double)GetValue(LetterSpacingProperty);
             set => SetValue(LetterSpacingProperty, value);
+        }
+        
+        /// <summary>
+        /// Gets or sets the background color.
+        /// </summary>
+        /// <remarks>
+        /// The default value is based on the Color value of <see cref="MaterialColorConfiguration.Secondary"/> if you are using a Material resource, otherwise the default value is <see cref="Color.Accent"/>
+        /// </remarks>
+        public new Color BackgroundColor
+        {
+            get => (Color)GetValue(BackgroundColorProperty);
+            set => SetValue(BackgroundColorProperty, value);
         }
 
         /// <summary>
@@ -100,8 +109,26 @@ namespace XF.Material.Forms.UI
                     case nameof(ButtonType):
                         ButtonTypeChanged(ButtonType);
                         break;
+                    case nameof(Style):
+                        SetStyleValues(Style);
+                        break;
                 }
             }
+        }
+
+        private void SetStyleValues(Style style)
+        {
+            style?.Setters.ForEach(s =>
+            {
+                if (s.Value is DynamicResource d)
+                {
+                    SetDynamicResource(s.Property, d.Key);
+                }
+                else
+                {
+                    SetValue(s.Property, s.Value);
+                }
+            });
         }
 
         private void ButtonTypeChanged(MaterialButtonType buttonType)

--- a/XF.Material/UI/MaterialButton.cs
+++ b/XF.Material/UI/MaterialButton.cs
@@ -17,7 +17,6 @@ namespace XF.Material.Forms.UI
         private readonly string[] _colorPropertyNames = { nameof(BackgroundColor), nameof(PressedBackgroundColor), nameof(DisabledBackgroundColor) };
 
         public static readonly BindableProperty AllCapsProperty = BindableProperty.Create(nameof(AllCaps), typeof(bool), typeof(MaterialButton), true);
-        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
         public static readonly BindableProperty ButtonTypeProperty = BindableProperty.Create(nameof(ButtonType), typeof(MaterialButtonType), typeof(MaterialButton), MaterialButtonType.Elevated);
         public static readonly BindableProperty DisabledBackgroundColorProperty = BindableProperty.Create(nameof(DisabledBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
         public static readonly BindableProperty PressedBackgroundColorProperty = BindableProperty.Create(nameof(PressedBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
@@ -58,18 +57,6 @@ namespace XF.Material.Forms.UI
         {
             get => (double)GetValue(LetterSpacingProperty);
             set => SetValue(LetterSpacingProperty, value);
-        }
-        
-        /// <summary>
-        /// Gets or sets the background color.
-        /// </summary>
-        /// <remarks>
-        /// The default value is based on the Color value of <see cref="MaterialColorConfiguration.Secondary"/> if you are using a Material resource, otherwise the default value is <see cref="Color.Accent"/>
-        /// </remarks>
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
         }
 
         /// <summary>

--- a/XF.Material/UI/MaterialButton.cs
+++ b/XF.Material/UI/MaterialButton.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using System.Runtime.CompilerServices;
 using Xamarin.Forms;
-using Xamarin.Forms.Internals;
 using XF.Material.Forms.Resources;
 
 namespace XF.Material.Forms.UI
@@ -16,9 +15,6 @@ namespace XF.Material.Forms.UI
         private static readonly Color OutlinedBorderColor = Color.FromHex("#1E000000");
 
         public static readonly BindableProperty AllCapsProperty = BindableProperty.Create(nameof(AllCaps), typeof(bool), typeof(MaterialButton), true);
-
-        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialButton), Material.Color.Secondary);
-
         public static readonly BindableProperty ButtonTypeProperty = BindableProperty.Create(nameof(ButtonType), typeof(MaterialButtonType), typeof(MaterialButton), MaterialButtonType.Elevated);
 
         public static readonly BindableProperty DisabledBackgroundColorProperty = BindableProperty.Create(nameof(DisabledBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
@@ -40,9 +36,9 @@ namespace XF.Material.Forms.UI
             SetDynamicResource(BackgroundColorProperty, MaterialConstants.Color.SECONDARY);
             SetDynamicResource(TextColorProperty, MaterialConstants.Color.ON_SECONDARY);
             SetDynamicResource(HeightRequestProperty, MaterialConstants.MATERIAL_BUTTON_HEIGHT);
-            SetDynamicResource(FontAttributesProperty, MaterialConstants.MATERIAL_FONTATTRIBUTE_BOLD);
         }
 
+        #region Dependency properties
         public MaterialElevation Elevation
         {
             get => (MaterialElevation)GetValue(ElevationProperty);
@@ -68,15 +64,6 @@ namespace XF.Material.Forms.UI
         }
 
         /// <summary>
-        /// Gets or sets the background color. The default value is based on the Color value of <see cref="MaterialColorConfiguration.Secondary"/> if you are using a Material resource, otherwise the default value is <see cref="Color.Accent"/>
-        /// </summary>
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
-        }
-
-        /// <summary>
         /// Gets or sets the type of this button. The default value is <see cref="MaterialButtonType.Elevated"/>
         /// </summary>
         public virtual MaterialButtonType ButtonType
@@ -96,6 +83,7 @@ namespace XF.Material.Forms.UI
             get => (Color)GetValue(PressedBackgroundColorProperty);
             set => SetValue(PressedBackgroundColorProperty, value);
         }
+        #endregion
 
         protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
         {
@@ -112,26 +100,8 @@ namespace XF.Material.Forms.UI
                     case nameof(ButtonType):
                         ButtonTypeChanged(ButtonType);
                         break;
-                    case nameof(Style):
-                        SetStyleValues(Style);
-                        break;
                 }
             }
-        }
-
-        private void SetStyleValues(Style style)
-        {
-            style?.Setters.ForEach(s =>
-            {
-                if (s.Value is DynamicResource d)
-                {
-                    SetDynamicResource(s.Property, d.Key);
-                }
-                else
-                {
-                    SetValue(s.Property, s.Value);
-                }
-            });
         }
 
         private void ButtonTypeChanged(MaterialButtonType buttonType)


### PR DESCRIPTION
What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug Fix

### :arrow_heading_down: What is the current behavior?

- Right icons are not displayed at all.
- Left icons may not be displayed correctly.
- Sometime the text disappears and is replaced by "..."

### :new: What is the new behavior (if this is a feature change)?

All works as expected
Also the margin in ContentLayout is correctly used. 
Also the Padding has a real effect.

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

Run ios project and open the MaterialButton test page

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
