### PR TITLE
Fix button sizing, and style that can't be applied from everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,11 +550,9 @@ A view that displays a text. Allows customizations to conform with the typograph
 ##### Properties
 `MaterialLabel` inherits the `Label` class.
 
-1. `LetterSpacing` - The spacing between the letters of each word in the text.
+1. `TypeScale` - In material design, these are categories on how the text are displayed. Each type scale has its own font family, font weight, font size, and letter spacing. For more info about type scale, read [here](#type-scale).
 
-2. `TypeScale` - In material design, these are categories on how the text are displayed. Each type scale has its own font family, font weight, font size, and letter spacing. For more info about type scale, read [here](#type-scale).
-
-3. `LineHeight` - The factor to multiply that will identify the distance between the base of a line of text to another. The default value is `1.4`.
+2. `LineHeight` - The factor to multiply that will identify the distance between the base of a line of text to another. The default value is `1.4`.
 
 #### Chips
 Chips are compact elements that represent an input, attribute, or action.

--- a/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
+++ b/Samples/MaterialMvvmSample/MaterialMvvmSample.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="6.0.1" />
-    <PackageReference Include="Vapolia.Xamarin.Svg.Forms" Version="3.3.0" />
+    <PackageReference Include="Vapolia.Xamarin.Svg.Forms" Version="4.0.0-pre7" />
     <PackageReference Include="Xamarin.Forms" Version="4.5.0.657" />
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.8" />
   </ItemGroup>

--- a/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialButtonView.xaml
@@ -3,19 +3,74 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="MaterialMvvmSample.Views.MaterialButtonView"
-    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material">
-    <ContentPage.Content>
-        <StackLayout Padding="20">
-            <material:MaterialButton Text="Welkom" Clicked="Btn_Clicked"/>
+    xmlns:material="clr-namespace:XF.Material.Forms.UI;assembly=XF.Material"
+    xmlns:xamForms="clr-namespace:XamSvg.XamForms;assembly=XamSvg.XamForms">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="material:MaterialButton" x:Key="TestStyle" CanCascade="True">
+                <Setter Property="BackgroundColor" Value="DarkSlateGray" />
+                <Setter Property="TextColor" Value="GreenYellow" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    <StackLayout Padding="20">
+        <material:MaterialButton Text="Welcome XF.Material" Clicked="Btn_Clicked" Style="{StaticResource TestStyle}" />
 
-            <material:MaterialButton AllCaps="True"
-                                     ButtonType="Elevated"
-                                     Elevation="2"
-                                     PressedBackgroundColor="Red"
-                                     HorizontalOptions="Center"
-                                     Text="Open Dialog"
-                                     VerticalOptions="Center"
-                                     Clicked="MaterialButton_Clicked"/>
-        </StackLayout>
-    </ContentPage.Content>
+        <material:MaterialButton AllCaps="True"
+                                 ButtonType="Elevated"
+                                 Elevation="2"
+                                 PressedBackgroundColor="Red"
+                                 BackgroundColor="GreenYellow"
+                                 TextColor="DarkGreen"
+                                 BorderColor="DarkGreen"
+                                 BorderWidth="1"
+                                 HorizontalOptions="Center"
+                                 Text="Open Dialog"
+                                 VerticalOptions="Center"
+                                 Clicked="MaterialButton_Clicked"/>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <material:MaterialButton Text="Left Long" HorizontalOptions="Start"/>
+            <material:MaterialButton Text="Mid" Grid.Column="1"  />
+            <material:MaterialButton Text="Right" Grid.Column="2" HorizontalOptions="End"/>
+        </Grid>
+
+        <Label Text="Defaut xamarin buttons for comparison:"/>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Button Text="Left" BackgroundColor="Yellow" ContentLayout="Left,30" HorizontalOptions="Start">
+                <Button.ImageSource>
+                    <xamForms:SvgImageSource Svg="images.slideshow-black-18dp.svg" Height="45" ColorMapping="000000=0000FF" />
+                </Button.ImageSource>
+            </Button>
+            <Button Text="Mid" Grid.Column="1" BackgroundColor="Yellow" />
+            <Button Text="Right" Grid.Column="2"  BackgroundColor="Yellow" HorizontalOptions="End" />
+        </Grid>
+
+        <Label Text="With icons:"/>
+        <material:MaterialButton Text="Left svg icon" ContentLayout="Left,10" HorizontalOptions="Start">
+            <Button.ImageSource>
+                <xamForms:SvgImageSource Svg="images.slideshow-black-18dp.svg" Height="45" ColorMapping="000000=FFFFFF" />
+            </Button.ImageSource>
+        </material:MaterialButton>
+        <material:MaterialButton Text="Left normal icon" ImageSource="ic_overflow" HorizontalOptions="Start" />
+
+        <material:MaterialButton Text="Right SVG icon" ContentLayout="Right,40" HorizontalOptions="Start">
+            <Button.ImageSource>
+                <xamForms:SvgImageSource Svg="images.slideshow-black-18dp" Height="45" ColorMapping="000000=FFFFFF" />
+            </Button.ImageSource>
+        </material:MaterialButton>
+        <material:MaterialButton Text="Right normal icon" ImageSource="ic_overflow" ContentLayout="Right" HorizontalOptions="Start" />
+    </StackLayout>
+
 </ContentPage>

--- a/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Android/Renderers/MaterialButtonRenderer.cs
@@ -21,35 +21,38 @@ namespace XF.Material.Droid.Renderers
         {
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _helper.Clean();
+            }
+            
+            base.Dispose(disposing);
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
         {
             base.OnElementChanged(e);
 
             if (Control == null)
-            {
                 return;
-            }
 
             if (e?.OldElement != null)
-            {
                 _helper.Clean();
-            }
 
             if (e?.NewElement == null)
-            {
                 return;
-            }
 
-            _materialButton = Element as MaterialButton;
+            _materialButton = (MaterialButton)Element;
             _helper = new MaterialDrawableHelper(_materialButton, Control);
             _helper.UpdateDrawable();
 
             Control.SetMinimumWidth((int)MaterialHelper.ConvertDpToPx(64));
             Control.SetAllCaps(_materialButton != null && _materialButton.AllCaps);
+            Control.SetMaxLines(1);
 
-            SetButtonIcon();
             SetTextColors();
-            SetTextLetterSpacing();
         }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -63,49 +66,15 @@ namespace XF.Material.Droid.Renderers
 
             switch (e?.PropertyName)
             {
-                case nameof(MaterialButton.ImageSource):
-                case nameof(MaterialButton.Image):
-                    SetButtonIcon();
-                    break;
                 case nameof(MaterialButton.AllCaps):
                     Control.SetAllCaps(_materialButton.AllCaps);
                     break;
                 case nameof(Button.TextColor):
                     SetTextColors();
                     break;
-                case nameof(MaterialButton.LetterSpacing):
-                    SetTextLetterSpacing();
-                    break;
             }
         }
 
-        private void SetButtonIcon()
-        {
-            var withIcon = !string.IsNullOrEmpty(_materialButton.Image) || !(_materialButton.ImageSource?.IsEmpty ?? true);
-            _helper.UpdateHasIcon(withIcon);
-
-            if (!withIcon)
-            {
-                return;
-            }
-
-            var drawable = Control.GetCompoundDrawables().FirstOrDefault(s => s != null);
-
-            if (drawable == null)
-            {
-                return;
-            }
-
-            var drawableCopy = drawable.GetDrawableCopy();
-            var width = _materialButton.ButtonType == MaterialButtonType.Text ? (int)MaterialHelper.ConvertDpToPx(18) : (int)MaterialHelper.ConvertDpToPx(18 + 4);
-            var height = (int)MaterialHelper.ConvertDpToPx(18);
-            var left = _materialButton.ButtonType == MaterialButtonType.Text ? 0 : (int)MaterialHelper.ConvertDpToPx(4);
-            drawableCopy.SetBounds(left, 0, width, height);
-            drawableCopy.TintDrawable(_materialButton.TextColor.ToAndroid());
-
-            Control.SetCompoundDrawables(drawableCopy, null, null, null);
-            Control.CompoundDrawablePadding = 0;
-        }
         private void SetTextColors()
         {
             var states = new[]
@@ -127,12 +96,6 @@ namespace XF.Material.Droid.Renderers
              };
 
             Control.SetTextColor(new ColorStateList(states, colors));
-        }
-
-        private void SetTextLetterSpacing()
-        {
-            var rawLetterSpacing = _materialButton.LetterSpacing / Control.TextSize;
-            Control.LetterSpacing = MaterialHelper.ConvertSpToPx(rawLetterSpacing);
         }
     }
 }

--- a/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialButtonRenderer.cs
@@ -42,7 +42,6 @@ namespace XF.Material.iOS.Renderers
 
             UpdateLayerFrame();
             UpdateCornerRadius();
-            UpdateTextSizing();
             UpdateButtonLayer();
             UpdateState();
         }
@@ -72,20 +71,13 @@ namespace XF.Material.iOS.Renderers
                 if (_materialButton != null)
                 {
                     _withIcon = _materialButton.Image != null || _materialButton.ImageSource != null && !_materialButton.ImageSource.IsEmpty;
-
-                    if (_materialButton.AllCaps)
-                    {
-                        _materialButton.Text = _materialButton.Text?.ToUpper();
-                    }
                 }
 
-                SetupIcon();
                 SetupColors();
-                UpdateText();
                 CreateStateAnimations();
                 UpdateButtonLayer();
                 UpdateState();
-                UpdateTextColor();
+                UpdateText();
                 Control.TouchDown += Control_Pressed;
                 Control.TouchDragEnter += Control_Pressed;
                 Control.TouchUpInside += Control_Released;
@@ -120,33 +112,18 @@ namespace XF.Material.iOS.Renderers
 
                 case nameof(MaterialButton.ImageSource):
                 case nameof(MaterialButton.Image):
-                    SetupIcon();
                     UpdateButtonLayer();
-                    break;
-
-                case nameof(MaterialButton.AllCaps):
-                    _materialButton.Text = _materialButton.AllCaps ? _materialButton.Text.ToUpper() : _materialButton.Text.ToLower();
+                    SetupIcon();
                     break;
 
                 case nameof(MaterialButton.CornerRadius):
                     UpdateCornerRadius();
                     break;
 
-                case nameof(MaterialButton.LetterSpacing):
-                    UpdateText();
-                    break;
-
                 case nameof(MaterialButton.Text):
-                    UpdateText();
-                    UpdateTextSizing();
-                    break;
-
-                case nameof(MaterialButton.Padding):
-                    UpdatePadding();
-                    break;
-
                 case nameof(MaterialButton.TextColor):
-                    UpdateTextColor();
+                case nameof(MaterialButton.AllCaps):
+                    UpdateText();
                     break;
             }
         }
@@ -298,49 +275,45 @@ namespace XF.Material.iOS.Renderers
             _disabledTextColor = _normalTextColor.GetDisabledColor();
         }
 
-        private async void SetupIcon()
+        private void SetupIcon()
         {
             if (_withIcon)
             {
-                UIImage image = null;
+                var control = Control;
+                control.TintColor = _materialButton.TextColor.ToUIColor();
 
-                try
-                {
-                    if (_materialButton.Image != null)
-                    {
-                        image = UIImage.FromFile(_materialButton.Image.File) ?? UIImage.FromBundle(_materialButton.Image.File);
-                    }
-                    else if (!(_materialButton.ImageSource?.IsEmpty ?? true))
-                    {
-                        IImageSourceHandler imageSourceHandler = _materialButton.ImageSource.GetImageSourceHandler();
-                        image = await imageSourceHandler.LoadImageAsync(_materialButton.ImageSource);
-                    }
-                    UIGraphics.BeginImageContextWithOptions(new CGSize(18, 18), false, 0f);
-                    image?.Draw(new CGRect(0, 0, 18, 18));
+                //if (Element.ContentLayout.Position == Button.ButtonContentLayout.ImagePosition.Right)
+                //{
+                //    //XF does not compute correctly the text's width
+                //    var imageSize = control.CurrentImage.Size;
 
-                    using (var newImage = UIGraphics.GetImageFromCurrentImageContext())
-                    {
-                        UIGraphics.EndImageContext();
-
-                        Control.SetImage(newImage, UIControlState.Normal);
-                        Control.SetImage(newImage, UIControlState.Disabled);
-
-                        Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Left;
-                        Control.ImageEdgeInsets = new UIEdgeInsets(0f, 0f, 0f, 0f);
-                        Control.TintColor = _materialButton.TextColor.ToUIColor();
-                    }
-                }
-                finally
-                {
-                    image?.Dispose();
-                }
-            }
-            else
-            {
-                Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
-                Control.HorizontalAlignment = UIControlContentHorizontalAlignment.Center;
+                //    if (imageSize.Width > 0 && imageSize.Height > 0)
+                //    {
+                //        var insets = Control.ImageEdgeInsets;
+                //        var margin = (nfloat)Element.ContentLayout.Spacing;
+                //        var deltaX = Control.CurrentAttributedTitle.Size.Width + Control.TitleEdgeInsets.Left + Control.TitleEdgeInsets.Right + margin;
+                //        Control.ImageEdgeInsets = new UIEdgeInsets(insets.Top, deltaX, insets.Bottom, -deltaX);
+                //    }
+                //}
             }
         }
+
+        ///// <summary>
+        ///// Computes the intrinsic content size
+        ///// </summary>
+        ///// <param name="size"></param>
+        ///// <remarks>
+        ///// Because CharacterSpacing is non standard, the width is incorrectly computed,
+        ///// leading to the button's width being too small.
+        ///// Adding 2x14 seems to fit all situations.
+        ///// </remarks>
+        //public override CGSize SizeThatFits(CGSize size)
+        //{
+        //    size = base.SizeThatFits(size);
+        //    if(size.Width > 0) //A negative value means "whatever"
+        //        size.Width += 28;
+        //    return size;
+        //}
 
         private Task<bool> UpdateBackgroundColor()
         {
@@ -384,51 +357,9 @@ namespace XF.Material.iOS.Renderers
                     CreateTextButtonLayer();
                     break;
             }
-
-            UpdatePadding();
-        }
-
-        private void UpdatePadding()
-        {
-            if (Control == null)
-            {
-                return;
-            }
-
-            var additionalPadding = Element.Padding;
-
-            if (_materialButton.ButtonType != MaterialButtonType.Text && _withIcon)
-            {
-                Control.ContentEdgeInsets = new UIEdgeInsets(
-                    10f + (nfloat)additionalPadding.Top,
-                    18f + (nfloat)additionalPadding.Left,
-                    10f + (nfloat)additionalPadding.Bottom,
-                    22f + (nfloat)additionalPadding.Right);
-            }
-            else if (_materialButton.ButtonType != MaterialButtonType.Text && !_withIcon)
-            {
-                Control.ContentEdgeInsets = new UIEdgeInsets(
-                    10f + (nfloat)additionalPadding.Top,
-                    22f + (nfloat)additionalPadding.Left,
-                    10f + (nfloat)additionalPadding.Bottom,
-                    22f + (nfloat)additionalPadding.Right);
-            }
-            else if (_materialButton.ButtonType is MaterialButtonType.Text && _withIcon)
-            {
-                Control.ContentEdgeInsets = new UIEdgeInsets(
-                    10f + (nfloat)additionalPadding.Top,
-                    18f + (nfloat)additionalPadding.Left,
-                    10f + (nfloat)additionalPadding.Bottom,
-                    22f + (nfloat)additionalPadding.Right);
-            }
-            else if (_materialButton.ButtonType is MaterialButtonType.Text && !_withIcon)
-            {
-                Control.ContentEdgeInsets = new UIEdgeInsets(
-                    10f + (nfloat)additionalPadding.Top,
-                    14f + (nfloat)additionalPadding.Left,
-                    10f + (nfloat)additionalPadding.Bottom,
-                    14f + (nfloat)additionalPadding.Right);
-            }
+            
+            _animationLayer.SetNeedsDisplay();
+            SetNeedsDisplay();
         }
 
         private void UpdateCornerRadius()
@@ -518,74 +449,17 @@ namespace XF.Material.iOS.Renderers
 
         private void UpdateText()
         {
-            if (Control == null || Control.TitleLabel.AttributedText == null)
-            {
-                return;
-            }
 
-            var text = Element.Text;
-            text = _materialButton.AllCaps ? text?.ToUpper() : text;
-            Control.TitleLabel.Text = text;
+            var text = Element.Text ?? String.Empty;
+            if (_materialButton.AllCaps)
+                text = text.ToUpper();
 
-            var range = new NSRange(0, text?.Length ?? 0);
-            var newAttr = new NSMutableAttributedString(Control.TitleLabel.AttributedText);
-            newAttr.AddAttribute(UIStringAttributeKey.KerningAdjustment, FromObject((float)_materialButton.LetterSpacing), range);
-
-            Control.SetAttributedTitle(newAttr, UIControlState.Normal);
-        }
-
-        private void UpdateTextSizing()
-        {
-            if (Control == null)
-            {
-                return;
-            }
-
-            if (string.IsNullOrEmpty(_materialButton.Text) || !_withIcon)
-            {
-                Control.TitleEdgeInsets = new UIEdgeInsets(0, 0, 0, 0);
-                return;
-            }
-
-            // We have to set the button title insets to make the button look
-            // like Android's material buttons. (icon on left, text is centralized)
-
-            var textToMeasure = (NSString)(_materialButton.Text ?? "");
-
-            var labelRect = textToMeasure.GetBoundingRect(
-                new CGSize(Frame.Width - 40, nfloat.MaxValue),
-                NSStringDrawingOptions.UsesLineFragmentOrigin,
-                new UIStringAttributes() { Font = Control.Font },
-                new NSStringDrawingContext()
-            );
-
-            var textWidth = (float)labelRect.Size.Width;
-            var buttonWidth = (float)Control.Frame.Width;
-
-            var inset = ((buttonWidth - textWidth) / 2) - 28;
-            Control.TitleEdgeInsets = new UIEdgeInsets(0, inset, 0, -40);
-        }
-
-        private void UpdateTextColor()
-        {
-            if (Control == null || Control.CurrentAttributedTitle == null)
-            {
-                return;
-            }
-
-            var title = new NSMutableAttributedString(Control.CurrentAttributedTitle);
-
-            title.EnumerateAttributes(new NSRange(0, title.Length), NSAttributedStringEnumeration.None,
-                (NSDictionary attrs, NSRange range, ref bool stop) =>
-                {
-                    title.BeginEditing();
-                    title.AddAttribute(UIStringAttributeKey.ForegroundColor, _materialButton.TextColor.ToUIColor(), range);
-                    title.EndEditing();
-                });
-
+            var title = new NSMutableAttributedString(text, kerning: (float)_materialButton.CharacterSpacing, foregroundColor: _materialButton.TextColor.ToUIColor());
             Control.SetAttributedTitle(title, UIControlState.Normal);
             Control.SetAttributedTitle(title, UIControlState.Highlighted);
             Control.SetAttributedTitle(title, UIControlState.Disabled);
+
+            SetupIcon();
         }
     }
 }

--- a/XF.Material/UI/MaterialButton.cs
+++ b/XF.Material/UI/MaterialButton.cs
@@ -14,22 +14,14 @@ namespace XF.Material.Forms.UI
         public const string MaterialButtonColorChanged = "BackgroundColorChanged";
 
         private static readonly Color OutlinedBorderColor = Color.FromHex("#1E000000");
+        private readonly string[] _colorPropertyNames = { nameof(BackgroundColor), nameof(PressedBackgroundColor), nameof(DisabledBackgroundColor) };
 
         public static readonly BindableProperty AllCapsProperty = BindableProperty.Create(nameof(AllCaps), typeof(bool), typeof(MaterialButton), true);
-
-        public static new readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialButton), Material.Color.Secondary);
-
         public static readonly BindableProperty ButtonTypeProperty = BindableProperty.Create(nameof(ButtonType), typeof(MaterialButtonType), typeof(MaterialButton), MaterialButtonType.Elevated);
-
         public static readonly BindableProperty DisabledBackgroundColorProperty = BindableProperty.Create(nameof(DisabledBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
-
         public static readonly BindableProperty PressedBackgroundColorProperty = BindableProperty.Create(nameof(PressedBackgroundColor), typeof(Color), typeof(MaterialButton), default(Color));
-
-        public static readonly BindableProperty LetterSpacingProperty = BindableProperty.Create(nameof(LetterSpacing), typeof(double), typeof(MaterialButton), 1.25);
-
         public static readonly BindableProperty ElevationProperty = BindableProperty.Create(nameof(Elevation), typeof(MaterialElevation), typeof(MaterialButton), new MaterialElevation(2, 8));
 
-        private readonly string[] _colorPropertyNames = { nameof(BackgroundColor), nameof(PressedBackgroundColor), nameof(DisabledBackgroundColor) };
 
         public MaterialButton()
         {
@@ -40,7 +32,7 @@ namespace XF.Material.Forms.UI
             SetDynamicResource(BackgroundColorProperty, MaterialConstants.Color.SECONDARY);
             SetDynamicResource(TextColorProperty, MaterialConstants.Color.ON_SECONDARY);
             SetDynamicResource(HeightRequestProperty, MaterialConstants.MATERIAL_BUTTON_HEIGHT);
-            SetDynamicResource(FontAttributesProperty, MaterialConstants.MATERIAL_FONTATTRIBUTE_BOLD);
+            CharacterSpacing = 2.25;
         }
 
         public MaterialElevation Elevation
@@ -58,23 +50,6 @@ namespace XF.Material.Forms.UI
             set => SetValue(AllCapsProperty, value);
         }
 
-        /// <summary>
-        /// Gets or sets the letter spacing of this button's text.
-        /// </summary>
-        public double LetterSpacing
-        {
-            get => (double)GetValue(LetterSpacingProperty);
-            set => SetValue(LetterSpacingProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the background color. The default value is based on the Color value of <see cref="MaterialColorConfiguration.Secondary"/> if you are using a Material resource, otherwise the default value is <see cref="Color.Accent"/>
-        /// </summary>
-        public new Color BackgroundColor
-        {
-            get => (Color)GetValue(BackgroundColorProperty);
-            set => SetValue(BackgroundColorProperty, value);
-        }
 
         /// <summary>
         /// Gets or sets the type of this button. The default value is <see cref="MaterialButtonType.Elevated"/>


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
- Remove MaterialButton.LetterSpacing and Image/ImageSource as Xamarin Forms now provides CharacterSpacing which conflict with this LetterSpacing, and provides better functionality for icons. 
- Also fix padding and incorrect auto sizing of the button on iOS, which shrinks vertically below its normal size.
- Also MaterialButton: remove BackgroundColor property as it overrides an existing base property which needs to be accessed by style, preventing this backgroundcolor from being changed using a global style.

### :arrow_heading_down: What is the current behavior?
- incorrect sizing, color changing randomly when styled

### :new: What is the new behavior (if this is a feature change)?
- all works as expected

### :boom: Does this PR introduce a breaking change?
Yes, LetterSpacing should be replaced by Xamarin Form's oob CharacterSpacing

### :bug: Recommendations for testing
Use the demo project which highlights the issues

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
