### PR TITLE
fix DatePicker on iOS 14 as Xamarin Forms did not in their code.

### DIFF
--- a/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
+++ b/Samples/MaterialMvvmSample.iOS/MaterialMvvmSample.iOS.csproj
@@ -221,4 +221,9 @@
   <ItemGroup>
     <BundleResource Include="Resources\xf_checkbox_selected%403x.png" />
   </ItemGroup>
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties TriggeredFromHotReload="False" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialTextFieldView.xaml
@@ -42,7 +42,8 @@
             <material:MaterialDateField Placeholder="Date" />
             <material:MaterialDateField Placeholder="Date, bottom tip, leading and trailing icons"
                                         HelperText="Your birthday"
-                                        Date="2020/08/28">
+                                        Date="2020/08/28"
+                                        Format="yyyy/MM/dd">
                 <material:MaterialDateField.LeadingIcon>
                     <xamForms:SvgImageSource Svg="res:images.slideshow-black-18dp" Height="200" />
                 </material:MaterialDateField.LeadingIcon>

--- a/XF.Material/Platforms/Ios/Renderers/MaterialDatePickerRenderer.cs
+++ b/XF.Material/Platforms/Ios/Renderers/MaterialDatePickerRenderer.cs
@@ -20,6 +20,13 @@ namespace XF.Material.iOS.Renderers
             {
                 Control.Layer.BorderWidth = 0;
                 Control.BorderStyle = UITextBorderStyle.None;
+
+                if (UIDevice.CurrentDevice.CheckSystemVersion(14, 0))
+                {
+                    var picker = Control?.InputView as UIDatePicker;
+                    if (picker != null)
+                        picker.PreferredDatePickerStyle = UIDatePickerStyle.Wheels;
+                }
             }
         }
 

--- a/XF.Material/UI/MaterialDateField.xaml
+++ b/XF.Material/UI/MaterialDateField.xaml
@@ -62,7 +62,9 @@
                                          TextColor="{Binding TextColor,Source={x:Reference ThisControl}}"
                                          VerticalOptions="Start"
                                          TintColor="{Binding TintColor,Source={x:Reference ThisControl}}"
-                                         BackgroundColor="Transparent" />
+                                         BackgroundColor="Transparent"
+                                         Format="{Binding Format}"
+                                         />
 
             <!-- persistentUnderline -->
             <BoxView

--- a/XF.Material/UI/MaterialDateField.xaml
+++ b/XF.Material/UI/MaterialDateField.xaml
@@ -63,7 +63,7 @@
                                          VerticalOptions="Start"
                                          TintColor="{Binding TintColor,Source={x:Reference ThisControl}}"
                                          BackgroundColor="Transparent"
-                                         Format="{Binding Format}"
+                                         Format="{Binding Format,Source={x:Reference ThisControl}}"
                                          />
 
             <!-- persistentUnderline -->

--- a/XF.Material/UI/MaterialDateField.xaml.cs
+++ b/XF.Material/UI/MaterialDateField.xaml.cs
@@ -58,7 +58,7 @@ namespace XF.Material.Forms.UI
         public static readonly BindableProperty DropDrownArrowIconProperty = BindableProperty.Create(nameof(DropDrownArrowIcon), typeof(ImageSource), typeof(MaterialDateField), new FileImageSource { File = "xf_arrow_dropdown" });
         public static readonly BindableProperty UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
         public new static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#DCDCDC"));
-        public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(MaterialDateField));
+        public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(MaterialDateField), "d");
 
         private readonly Easing _animationCurve = Easing.SinOut;
         private readonly Dictionary<string, Action> _propertyChangeActions;

--- a/XF.Material/UI/MaterialDateField.xaml.cs
+++ b/XF.Material/UI/MaterialDateField.xaml.cs
@@ -58,6 +58,7 @@ namespace XF.Material.Forms.UI
         public static readonly BindableProperty DropDrownArrowIconProperty = BindableProperty.Create(nameof(DropDrownArrowIcon), typeof(ImageSource), typeof(MaterialDateField), new FileImageSource { File = "xf_arrow_dropdown" });
         public static readonly BindableProperty UnderlineColorProperty = BindableProperty.Create(nameof(UnderlineColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#99000000"));
         public new static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(MaterialDateField), Color.FromHex("#DCDCDC"));
+        public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(MaterialDateField));
 
         private readonly Easing _animationCurve = Easing.SinOut;
         private readonly Dictionary<string, Action> _propertyChangeActions;
@@ -128,6 +129,15 @@ namespace XF.Material.Forms.UI
         {
             get => (Color)GetValue(BackgroundColorProperty);
             set => SetValue(BackgroundColorProperty, value);
+        }
+
+        /// <summary>
+        /// String format for the date
+        /// </summary>
+        public string Format
+        {
+            get => (string)GetValue(FormatProperty);
+            set => SetValue(FormatProperty, value);
         }
 
         [TypeConverter(typeof(ImageSourceConverter))]


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix: MaterialDateField was not working properly on iOS 14.

### :arrow_heading_down: What is the current behavior?
MaterialDateField displays a wheel area, which contains a single text. Tapping the text opens the new popup date picker of ios 14. This needs 2 actions from the user.

### :new: What is the new behavior (if this is a feature change)?
MaterialDateField displays a wheel as expected.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
open the demo project on MaterialTextFields on iOS 14. Tap on MaterialDateField.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
