### PR TITLE
add readonly mode

### DIFF
--- a/XF.Material/UI/MaterialTextField.xaml.cs
+++ b/XF.Material/UI/MaterialTextField.xaml.cs
@@ -1157,6 +1157,9 @@ namespace XF.Material.Forms.UI
 
         private void OnInputTypeChanged()
         {
+            entry.IsReadOnly = false;
+            entry.Keyboard = Keyboard.Default;
+
             switch (InputType)
             {
                 case MaterialTextFieldInputType.Chat:
@@ -1225,6 +1228,10 @@ namespace XF.Material.Forms.UI
                 case MaterialTextFieldInputType.Choice:
                 case MaterialTextFieldInputType.SingleImmediateChoice:
                 case MaterialTextFieldInputType.CommandChoice:
+                    break;
+
+                case MaterialTextFieldInputType.ReadOnly:
+                    entry.IsReadOnly = true;
                     break;
             }
 

--- a/XF.Material/UI/MaterialTextFieldInputType.cs
+++ b/XF.Material/UI/MaterialTextFieldInputType.cs
@@ -23,6 +23,10 @@
         /// <summary>
         /// Triggers the command when clicked instead of focusing the input field
         /// </summary>
-        CommandChoice
+        CommandChoice,
+        /// <summary>
+        /// Does not allow changes, and does not gray out the control
+        /// </summary>
+        ReadOnly
     }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Add new feature

### :arrow_heading_down: What is the current behavior?

There is no way to set the field as readonly (ie: field is enabled, but all actions on it are disabled except copy)

### :new: What is the new behavior (if this is a feature change)?

MaterialTextFieldInputType has now a ReadOnly value

### :boom: Does this PR introduce a breaking change?

no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [ ] Relevant documentation was updated
- [X] Rebased onto current develop
