### PR TITLE
Fix issue#426: Spacing between two dialog button

### DIFF
--- a/Samples/MaterialMvvmSample.Android/MainActivity.cs
+++ b/Samples/MaterialMvvmSample.Android/MainActivity.cs
@@ -14,7 +14,7 @@ namespace MaterialMvvmSample.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(savedInstanceState);
-            Rg.Plugins.Popup.Popup.Init(this, savedInstanceState);
+            Rg.Plugins.Popup.Popup.Init(this);
             Xamarin.Forms.Forms.Init(this, savedInstanceState);
             Material.Init(this, savedInstanceState);
 

--- a/XF.Material/UI/Dialogs/MaterialAlertDialog.xaml
+++ b/XF.Material/UI/Dialogs/MaterialAlertDialog.xaml
@@ -69,6 +69,12 @@
                                              Margin="0,0,-8,0"
                                              ButtonType="Text"
                                              VerticalOptions="Center">
+                        <material:MaterialButton.Margin>
+                            <OnPlatform x:TypeArguments="Thickness">
+                                <On Platform="iOS"
+                                    Value="0,0,10,0" />
+                            </OnPlatform>
+                        </material:MaterialButton.Margin>
                         <material:MaterialButton.Triggers>
                             <Trigger TargetType="Button" Property="Text" Value="{x:Null}">
                                 <Setter Property="IsVisible" Value="False" />

--- a/XF.Material/UI/Dialogs/MaterialConfirmationDialog.xaml
+++ b/XF.Material/UI/Dialogs/MaterialConfirmationDialog.xaml
@@ -74,6 +74,12 @@
                                              ButtonType="Text"
                                              Text="Cancel"
                                              VerticalOptions="Center">
+                        <material:MaterialButton.Margin>
+                            <OnPlatform x:TypeArguments="Thickness">
+                                <On Platform="iOS"
+                                    Value="0,0,10,0" />
+                            </OnPlatform>
+                        </material:MaterialButton.Margin>
                         <material:MaterialButton.Triggers>
                             <Trigger TargetType="Button" Property="Text" Value="{x:Null}">
                                 <Setter Property="IsVisible" Value="False" />


### PR DESCRIPTION
### Introduction
Hi folks 👋🏻, 
There are not many changes in this PR but they are quite important.
This PR fixes issue #426. Before then, on both MaterialConfirmationDialog and MaterialAlertDialog their buttons going on top of each other as you can see on the screenshots below.
Also, this issue only appeared on iOS, it might be the reason why it was more difficult to detect.

### :sparkles: What kind of change does this PR introduce? (Bugfix, feature, docs update...)
- MaterialConfirmationDialog.xaml and MaterialAlertDialog.xaml: I put a right margin on the first button. (only for iOS)

### :arrow_heading_down: What is the current behaviour?
![Before](https://user-images.githubusercontent.com/37577669/124829472-f71eea00-df78-11eb-8751-dc06466ba9a3.png)


### :new: What is the new behaviour?
![After](https://user-images.githubusercontent.com/37577669/124829508-03a34280-df79-11eb-93ca-2ceb5cb51ff4.png)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Rebased onto current develop
