### PR TITLE
Fix spacing buttons Input Dialog

### DIFF
--- a/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml
+++ b/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml
@@ -16,6 +16,12 @@
 
             <material:MaterialButton Text="Open Alert Dialog"
                                      Clicked="OpenAlertDialog_Clicked"/>
+            
+            <material:MaterialButton Text="Open Input Dialog"
+                                     Clicked="OpenInputDialog_Clicked"/>
+            
+            <material:MaterialButton Text="Open select Dialog"
+                                     Clicked="OpenSelectDialog_Clicked"/>
 
         </StackLayout>
     </ContentPage.Content>

--- a/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml.cs
@@ -91,5 +91,21 @@ namespace MaterialMvvmSample.Views
                 Debug.WriteLine("Closed");
             }
         }
+
+        private async void OpenInputDialog_Clicked(object sender, EventArgs e)
+        {
+            await MaterialDialog.Instance.InputAsync("Message", "Title", "Confirm", "Dismiss");
+        }
+
+        private async void OpenSelectDialog_Clicked(object sender, EventArgs e)
+        {
+            var choices = new List<string>()
+            {
+                "Choice 1",
+                "Choice 1",
+                "Choice 3",
+            };
+            await MaterialDialog.Instance.SelectChoiceAsync("Title", choices, "Confirm", "Dismiss");
+        }
     }
 }

--- a/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml.cs
+++ b/Samples/MaterialMvvmSample/Views/MaterialDialogsView.xaml.cs
@@ -105,7 +105,7 @@ namespace MaterialMvvmSample.Views
                 "Choice 1",
                 "Choice 3",
             };
-            await MaterialDialog.Instance.SelectChoiceAsync("Title", choices, "Confirm", "Dismiss");
+            await MaterialDialog.Instance.SelectChoiceAsync("Title", choices, "ok", "Cancel");
         }
     }
 }

--- a/XF.Material/UI/Dialogs/MaterialInputDialog.xaml
+++ b/XF.Material/UI/Dialogs/MaterialInputDialog.xaml
@@ -86,6 +86,12 @@
                                              Margin="0,0,-8,0"
                                              ButtonType="Text"
                                              VerticalOptions="Center">
+                            <material:MaterialButton.Margin>
+                                <OnPlatform x:TypeArguments="Thickness">
+                                    <On Platform="iOS"
+                                        Value="0,0,10,0" />
+                                </OnPlatform>
+                            </material:MaterialButton.Margin>
                             <material:MaterialButton.Triggers>
                                 <Trigger TargetType="Button" Property="Text" Value="{x:Null}">
                                     <Setter Property="IsVisible" Value="False" />


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Fix a bug related to the spacing between inputdialog spacing (see issue #434).
Should have been integrated to PR #426, but I forgot 😅 (oopsy)

### :arrow_heading_down: What is the current behavior?

![Before](https://user-images.githubusercontent.com/37577669/134774765-84625c09-f2db-4bc1-b731-f8e4466e9bb5.png)

### :new: What is the new behaviour (if this is a feature change)?
![After](https://user-images.githubusercontent.com/37577669/134774788-2e75f558-c362-4c95-aedb-afa497c4ba83.png)


### :boom: Does this PR introduce a breaking change?
Quite a bit yes

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Rebased onto current develop

closes #434.
