### PR TITLE
Fixed a bug with setresult causing exception, when action was trigger…

### DIFF
--- a/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml.cs
+++ b/XF.Material/UI/Dialogs/MaterialMenuDialog.xaml.cs
@@ -111,12 +111,12 @@ namespace XF.Material.Forms.UI.Dialogs
 
         protected override void OnBackButtonDismissed()
         {
-            InputTaskCompletionSource.SetResult(-1);
+            InputTaskCompletionSource.TrySetResult(-1);
         }
 
         protected override bool OnBackgroundClicked()
         {
-            InputTaskCompletionSource.SetResult(-1);
+            InputTaskCompletionSource.TrySetResult(-1);
 
             return base.OnBackgroundClicked();
         }
@@ -160,7 +160,7 @@ namespace XF.Material.Forms.UI.Dialogs
 
                     actionModel.IsSelected = true;
                     await DismissAsync();
-                    InputTaskCompletionSource?.SetResult(position);
+                    InputTaskCompletionSource?.TrySetResult(position);
                 });
                 actionModel.SizeChangeCommand = new Command<Dictionary<string, object>>(LabelSizeChanged);
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix

### :arrow_heading_down: What is the current behavior?
Currently the iOS implementation of `MaterialMenuDialog` will crash when a user taps twice on an action in the menu.

### :new: What is the new behavior (if this is a feature change)?
Will not crash anymore.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Double-tap an item in the `MaterialMenuDialog` to see if it does not crash on iOS now.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/XF-Material-Library/issues/439

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
