### PR TITLE
Fixed slider with non-zero minimum

### DIFF
--- a/XF.Material/UI/MaterialSlider.xaml.cs
+++ b/XF.Material/UI/MaterialSlider.xaml.cs
@@ -214,6 +214,7 @@ namespace XF.Material.Forms.UI
 
         private void AnimateDragger()
         {
+            var percentage = (Value - MinValue) / (MaxValue - MinValue);
             Dragger.TranslationX = percentage * Placeholder.Width;
             Indicator.WidthRequest = Dragger.TranslationX;
         }

--- a/XF.Material/UI/MaterialSlider.xaml.cs
+++ b/XF.Material/UI/MaterialSlider.xaml.cs
@@ -214,7 +214,6 @@ namespace XF.Material.Forms.UI
 
         private void AnimateDragger()
         {
-            var percentage = Value / (MaxValue - MinValue);
             Dragger.TranslationX = percentage * Placeholder.Width;
             Indicator.WidthRequest = Dragger.TranslationX;
         }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?

<img src="https://github.com/Baseflow/XF-Material-Library/assets/51406965/5be3e958-7e4d-4922-805e-2f40eb82f87c " height="900" />

Here I got all the sliders set to [1-10] as min and max values. There is no issue as to what the slider returns, but the graphic is glitched, and the knob does not follow my thumb. It is instead offsetted to the right. 

### <s> :new: What is the new behavior (if this is a feature change)?</s>


### :boom: Does this PR introduce a breaking change?
No breaking change in sight. 

### :bug: Recommendations for testing
Have a slider with a non-zero minimum. 

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
